### PR TITLE
Add support for prefix '_' and '$' in AccessorsInfo.

### DIFF
--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/field/AccessorsInfo.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/field/AccessorsInfo.java
@@ -100,6 +100,6 @@ public class AccessorsInfo {
   private boolean canPrefixApply(String fieldName, String prefix) {
     final int prefixLength = prefix.length();
     return fieldName.startsWith(prefix) && fieldName.length() > prefixLength &&
-        (prefixLength == 0 || Character.isUpperCase(fieldName.charAt(prefixLength)));
+        (prefixLength == 0 || Character.isUpperCase(fieldName.charAt(prefixLength)) || prefix.matches("_|\\$"));
   }
 }

--- a/lombok-plugin/src/test/data/after/Accessors.java
+++ b/lombok-plugin/src/test/data/after/Accessors.java
@@ -91,6 +91,18 @@ class AccessorsPrefix3 {
 		return result;
 	}
 }
+class AccessorsPrefix4 {
+  private String _underscore;
+  private String $DollarSign;
+  @java.lang.SuppressWarnings("all")
+  public void setUnderscore(final String _underscore) {
+    this._underscore = _underscore;
+  }
+  @java.lang.SuppressWarnings("all")
+  public void setDollarSign(final String $DollarSign) {
+    this.$DollarSign = $DollarSign;
+  }
+}
 class AccessorsFluentGenerics<T extends Number> {
 	private String name;
 	@java.lang.SuppressWarnings("all")

--- a/lombok-plugin/src/test/data/before/Accessors.java
+++ b/lombok-plugin/src/test/data/before/Accessors.java
@@ -37,6 +37,12 @@ class AccessorsPrefix3 {
 	}
 }
 
+@lombok.experimental.Accessors(prefix={"_", "$"})
+class AccessorsPrefix4 {
+  @lombok.Setter private String _underscore;
+  @lombok.Setter private String $DollarSign;
+}
+
 class AccessorsFluentGenerics<T extends Number> {
 	@lombok.Setter @lombok.experimental.Accessors(fluent=true) private String name;
 }


### PR DESCRIPTION
The '@Accessors' documentation says: 'For characters which are letters,
the character following the prefix must not be a lowercase letter ...'
(http://projectlombok.org/features/experimental/Accessors.html).

Both characters '_' and '$' are valid prefixes of Java identifiers. The
Plugin should not require the first letter after these prefixes to be
uppercase.
