### PR TITLE
Fixed @Accessors with non letter prefixes

### DIFF
--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/field/AccessorsInfo.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/field/AccessorsInfo.java
@@ -100,6 +100,6 @@ public class AccessorsInfo {
   private boolean canPrefixApply(String fieldName, String prefix) {
     final int prefixLength = prefix.length();
     return fieldName.startsWith(prefix) && fieldName.length() > prefixLength &&
-        (prefixLength == 0 || Character.isUpperCase(fieldName.charAt(prefixLength)) || prefix.matches("_|\\$"));
+        (prefixLength == 0 || Character.isUpperCase(fieldName.charAt(prefixLength)) || !Character.isLetter(fieldName.charAt(prefixLength-1)) );
   }
 }

--- a/lombok-plugin/src/test/data/after/Accessors.java
+++ b/lombok-plugin/src/test/data/after/Accessors.java
@@ -94,6 +94,9 @@ class AccessorsPrefix3 {
 class AccessorsPrefix4 {
   private String _underscore;
   private String $DollarSign;
+  private String m_fieldName;
+  private String foo;
+  private String bAr;
   @java.lang.SuppressWarnings("all")
   public void setUnderscore(final String _underscore) {
     this._underscore = _underscore;
@@ -101,6 +104,14 @@ class AccessorsPrefix4 {
   @java.lang.SuppressWarnings("all")
   public void setDollarSign(final String $DollarSign) {
     this.$DollarSign = $DollarSign;
+  }
+  @java.lang.SuppressWarnings("all")
+  public void setFieldName(final String m_fieldName) {
+    this.m_fieldName = m_fieldName;
+  }
+  @java.lang.SuppressWarnings("all")
+  public void setAr(final String bAr) {
+    this.bAr = bAr;
   }
 }
 class AccessorsFluentGenerics<T extends Number> {

--- a/lombok-plugin/src/test/data/before/Accessors.java
+++ b/lombok-plugin/src/test/data/before/Accessors.java
@@ -37,10 +37,13 @@ class AccessorsPrefix3 {
 	}
 }
 
-@lombok.experimental.Accessors(prefix={"_", "$"})
+@lombok.experimental.Accessors(prefix={"_", "$", "m_", "f", "b"})
 class AccessorsPrefix4 {
   @lombok.Setter private String _underscore;
   @lombok.Setter private String $DollarSign;
+  @lombok.Setter private String m_fieldName;
+  @lombok.Setter private String foo;
+  @lombok.Setter private String bAr;
 }
 
 class AccessorsFluentGenerics<T extends Number> {


### PR DESCRIPTION
Hi Michail, 

sorry for my late response. After reviewing the lombok implementation the previous change missed some cases: Only the prefixes '_' and '$' where handled, but all prefixes that end with a non letter
characters must be handled the same way.
