### PR TITLE
Add onX support

### DIFF
--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/action/delombok/BaseDelombokHandler.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/action/delombok/BaseDelombokHandler.java
@@ -166,6 +166,15 @@ public class BaseDelombokHandler {
 
     for (PsiParameter parameter : fromMethod.getParameterList().getParameters()) {
       PsiParameter param = elementFactory.createParameter(parameter.getName(), parameter.getType());
+      if (parameter.getModifierList() != null) {
+        PsiModifierList modifierList = param.getModifierList();
+        for (PsiAnnotation originalAnnotation : parameter.getModifierList().getAnnotations()) {
+          final PsiAnnotation annotation = modifierList.addAnnotation(originalAnnotation.getQualifiedName());
+          for (PsiNameValuePair nameValuePair : originalAnnotation.getParameterList().getAttributes()) {
+            annotation.setDeclaredAttributeValue(nameValuePair.getName(), nameValuePair.getValue());
+          }
+        }
+      }
       resultMethod.getParameterList().add(param);
     }
 

--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/extension/LombokHighlightErrorFilter.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/extension/LombokHighlightErrorFilter.java
@@ -6,21 +6,31 @@ import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiFile;
 import de.plushnikov.intellij.plugin.handler.LazyGetterHandler;
+import de.plushnikov.intellij.plugin.handler.OnXAnnotationHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.regex.Pattern;
 
 public class LombokHighlightErrorFilter implements HighlightInfoFilter {
-
   private static final Pattern UNINITIALIZED_MESSAGE = Pattern.compile("Variable '.+' might not have been initialized");
+  private static final Pattern LOMBOK_ANYANNOTATIONREQUIRED = Pattern.compile("Incompatible types\\. Found: '__*', required: 'lombok.*AnyAnnotation\\[\\]'");
 
   @Override
   public boolean accept(@NotNull HighlightInfo highlightInfo, @Nullable PsiFile file) {
     if (null != file && HighlightSeverity.ERROR.equals(highlightInfo.getSeverity())) {
 
+      String description = StringUtil.notNullize(highlightInfo.getDescription());
+      
       // Handling LazyGetter
-      if (uninitializedField(highlightInfo.getDescription()) && LazyGetterHandler.isLazyGetterHandled(highlightInfo, file)) {
+      if (uninitializedField(description) && LazyGetterHandler.isLazyGetterHandled(highlightInfo, file)) {
+        return false;
+      }
+      
+      //Handling onX parameters
+      if (OnXAnnotationHandler.isOnXParameterAnnotation(highlightInfo, file)
+          || OnXAnnotationHandler.isOnXParameterValue(highlightInfo, file)
+          || LOMBOK_ANYANNOTATIONREQUIRED.matcher(description).matches()) {
         return false;
       }
     }
@@ -28,6 +38,6 @@ public class LombokHighlightErrorFilter implements HighlightInfoFilter {
   }
 
   private boolean uninitializedField(String description) {
-    return UNINITIALIZED_MESSAGE.matcher(StringUtil.notNullize(description)).matches();
+    return UNINITIALIZED_MESSAGE.matcher(description).matches();
   }
 }

--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/handler/OnXAnnotationHandler.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/handler/OnXAnnotationHandler.java
@@ -46,12 +46,12 @@ public class OnXAnnotationHandler {
       return false;
     }
 
-    String parameterName = nameValuePair.getFirstChild().getText();
+    String parameterName = nameValuePair.getName();
     if (!ONX_PARAMETERS.contains(parameterName)) {
       return false;
     }
     
-    PsiElement containingAnnotation = nameValuePair.getContext().getPrevSibling().getContext();
+    PsiElement containingAnnotation = nameValuePair.getContext().getContext();
     return containingAnnotation instanceof PsiAnnotation && ONXABLE_ANNOTATIONS.contains(((PsiAnnotation) containingAnnotation).getQualifiedName());
   }
   

--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/handler/OnXAnnotationHandler.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/handler/OnXAnnotationHandler.java
@@ -1,0 +1,81 @@
+package de.plushnikov.intellij.plugin.handler;
+
+import com.google.common.collect.ImmutableList;
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiAnnotationParameterList;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiNameValuePair;
+
+import java.util.regex.Pattern;
+
+public class OnXAnnotationHandler {
+  private static final Pattern UNDERSCORES = Pattern.compile("__*");
+  private static final Pattern CANNOT_RESOLVE_UNDERSCORES_MESSAGE = Pattern.compile("Cannot resolve symbol '__*'");
+  
+  private static final String ANNOTATION_TYPE_EXPECTED = "Annotation type expected";
+  private static final String CANNOT_FIND_METHOD_VALUE_MESSAGE = "Cannot find method 'value'";
+  
+  private static final ImmutableList<String> ONXABLE_ANNOTATIONS = ImmutableList.of(
+      "lombok.Getter",
+      "lombok.Setter",
+      "lombok.experimental.Wither",
+      "lombok.NoArgsConstructor",
+      "lombok.RequiredArgsConstructor",
+      "lombok.AllArgsConstructor",
+      "lombok.EqualsAndHashCode"
+  );
+  private static final ImmutableList<String> ONX_PARAMETERS = ImmutableList.of(
+      "onConstructor",
+      "onMethod",
+      "onParam"
+  );
+
+  public static boolean isOnXParameterAnnotation(HighlightInfo highlightInfo, PsiFile file) {
+    if (!(ANNOTATION_TYPE_EXPECTED.equals(highlightInfo.getDescription())
+        || CANNOT_RESOLVE_UNDERSCORES_MESSAGE.matcher(StringUtil.notNullize(highlightInfo.getDescription())).matches())) {
+      return false;
+    }
+    
+    PsiElement highlightedElement = file.findElementAt(highlightInfo.getStartOffset());
+    
+    PsiNameValuePair nameValuePair = findContainingNameValuePair(highlightedElement);
+    if (nameValuePair == null || !(nameValuePair.getContext() instanceof PsiAnnotationParameterList)) {
+      return false;
+    }
+
+    String parameterName = nameValuePair.getFirstChild().getText();
+    if (!ONX_PARAMETERS.contains(parameterName)) {
+      return false;
+    }
+    
+    PsiElement containingAnnotation = nameValuePair.getContext().getPrevSibling().getContext();
+    return containingAnnotation instanceof PsiAnnotation && ONXABLE_ANNOTATIONS.contains(((PsiAnnotation) containingAnnotation).getQualifiedName());
+  }
+  
+  public static boolean isOnXParameterValue(HighlightInfo highlightInfo, PsiFile file) {
+    if (!CANNOT_FIND_METHOD_VALUE_MESSAGE.equals(highlightInfo.getDescription())) {
+      return false;
+    }
+
+    PsiElement highlightedElement = file.findElementAt(highlightInfo.getStartOffset());
+    PsiNameValuePair nameValuePair = findContainingNameValuePair(highlightedElement);
+    if (nameValuePair == null || !(nameValuePair.getContext() instanceof PsiAnnotationParameterList)) {
+      return false;
+    }
+
+    PsiElement leftSibling = nameValuePair.getContext().getPrevSibling();
+    return (leftSibling != null && UNDERSCORES.matcher(StringUtil.notNullize(leftSibling.getText())).matches());
+  }
+
+  private static PsiNameValuePair findContainingNameValuePair(PsiElement highlightedElement) {
+    PsiElement nameValuePair = highlightedElement;
+    while (!(nameValuePair == null || nameValuePair instanceof PsiNameValuePair)) {
+      nameValuePair = nameValuePair.getContext();
+    }
+    
+    return (PsiNameValuePair) nameValuePair;
+  }
+}

--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/AbstractProcessor.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/AbstractProcessor.java
@@ -6,15 +6,18 @@ import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.PsiModifierListOwner;
 import com.intellij.psi.PsiType;
 import de.plushnikov.intellij.plugin.lombokconfig.ConfigDiscovery;
 import de.plushnikov.intellij.plugin.lombokconfig.ConfigKeys;
 import de.plushnikov.intellij.plugin.processor.field.AccessorsInfo;
 import de.plushnikov.intellij.plugin.thirdparty.LombokUtils;
+import de.plushnikov.intellij.plugin.util.LombokProcessorUtil;
 import de.plushnikov.intellij.plugin.util.PsiAnnotationUtil;
 import lombok.experimental.Tolerate;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
@@ -123,5 +126,18 @@ public abstract class AbstractProcessor implements Processor {
       result = declaredAnnotationValue;
     }
     return result;
+  }
+
+  protected static void addOnXAnnotations(@Nullable PsiAnnotation processedAnnotation,
+                                          @NotNull PsiModifierList modifierList,
+                                          @NotNull String onXParameterName) {
+    if (processedAnnotation == null) {
+      return;
+    }
+
+    Collection<String> annotationsToAdd = LombokProcessorUtil.getOnX(processedAnnotation, onXParameterName);
+    for (String annotation : annotationsToAdd) {
+      modifierList.addAnnotation(annotation);
+    }
   }
 }

--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/constructor/AbstractConstructorClassProcessor.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/constructor/AbstractConstructorClassProcessor.java
@@ -196,6 +196,7 @@ public abstract class AbstractConstructorClassProcessor extends AbstractClassPro
         .withModifier(modifier);
 
     final AccessorsInfo accessorsInfo = AccessorsInfo.build(psiClass);
+    final PsiModifierList modifierList = constructor.getModifierList();
 
     if (!suppressConstructorProperties && !params.isEmpty()) {
       StringBuilder constructorPropertiesAnnotation = new StringBuilder("java.beans.ConstructorProperties( {");
@@ -205,8 +206,10 @@ public abstract class AbstractConstructorClassProcessor extends AbstractClassPro
       constructorPropertiesAnnotation.deleteCharAt(constructorPropertiesAnnotation.length() - 1);
       constructorPropertiesAnnotation.append("} ) ");
 
-      constructor.getModifierList().addAnnotation(constructorPropertiesAnnotation.toString());
+      modifierList.addAnnotation(constructorPropertiesAnnotation.toString());
     }
+
+    addOnXAnnotations(psiAnnotation, modifierList, "onConstructor");
 
     for (PsiField param : params) {
       constructor.withParameter(accessorsInfo.removePrefix(param.getName()), param.getType());

--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/field/GetterFieldProcessor.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/field/GetterFieldProcessor.java
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.PsiType;
 import de.plushnikov.intellij.plugin.problem.ProblemBuilder;
 import de.plushnikov.intellij.plugin.psi.LombokLightMethodBuilder;
@@ -135,8 +136,10 @@ public class GetterFieldProcessor extends AbstractFieldProcessor {
 
     method.withBody(PsiMethodUtil.createCodeBlockFromText(String.format("return %s.%s;", isStatic ? psiClass.getName() : "this", psiField.getName()), psiClass));
 
-    copyAnnotations(psiField, method.getModifierList(),
+    PsiModifierList modifierList = method.getModifierList();
+    copyAnnotations(psiField, modifierList,
         LombokUtils.NON_NULL_PATTERN, LombokUtils.NULLABLE_PATTERN, LombokUtils.DEPRECATED_PATTERN);
+    addOnXAnnotations(PsiAnnotationUtil.findAnnotation(psiField, Getter.class), modifierList, "onMethod");
     return method;
   }
 }

--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/field/SetterFieldProcessor.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/field/SetterFieldProcessor.java
@@ -126,6 +126,7 @@ public class SetterFieldProcessor extends AbstractFieldProcessor {
   public PsiMethod createSetterMethod(@NotNull PsiField psiField, @NotNull PsiClass psiClass, @NotNull String methodModifier) {
     final String fieldName = psiField.getName();
     final PsiType psiFieldType = psiField.getType();
+    final PsiAnnotation setterAnnotation = PsiAnnotationUtil.findAnnotation(psiField, Setter.class);
 
     final String methodName = getSetterName(psiField, PsiType.BOOLEAN.equals(psiFieldType));
 
@@ -151,7 +152,9 @@ public class SetterFieldProcessor extends AbstractFieldProcessor {
       for (String annotationFQN : annotationsToCopy) {
         methodParameterModifierList.addAnnotation(annotationFQN);
       }
+      addOnXAnnotations(setterAnnotation, methodParameterModifierList, "onParam");
     }
+
 
     final String thisOrClass = isStatic ? psiClass.getName() : "this";
     String blockText = String.format("%s.%s = %s;", thisOrClass, psiField.getName(), methodParameter.getName());
@@ -161,7 +164,9 @@ public class SetterFieldProcessor extends AbstractFieldProcessor {
 
     method.withBody(PsiMethodUtil.createCodeBlockFromText(blockText, psiClass));
 
-    copyAnnotations(psiField, method.getModifierList(), LombokUtils.DEPRECATED_PATTERN);
+    PsiModifierList methodModifierList = method.getModifierList();
+    copyAnnotations(psiField, methodModifierList, LombokUtils.DEPRECATED_PATTERN);
+    addOnXAnnotations(setterAnnotation, methodModifierList, "onMethod");
 
     return method;
   }

--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/field/WitherFieldProcessor.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/processor/field/WitherFieldProcessor.java
@@ -7,6 +7,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.PsiType;
 import com.intellij.util.StringBuilderSpinAllocator;
 import de.plushnikov.intellij.plugin.problem.ProblemBuilder;
@@ -181,8 +182,14 @@ public class WitherFieldProcessor extends AbstractFieldProcessor {
           .withNavigationElement(psiField)
           .withModifier(methodModifier);
 
+      PsiAnnotation witherAnnotation = PsiAnnotationUtil.findAnnotation(psiField, Wither.class);
+      addOnXAnnotations(witherAnnotation, result.getModifierList(), "onMethod");
+
       final LombokLightParameter methodParameter = new LombokLightParameter(psiFieldName, psiFieldType, result, JavaLanguage.INSTANCE);
-      copyAnnotations(psiField, methodParameter.getModifierList(), LombokUtils.NON_NULL_PATTERN, LombokUtils.NULLABLE_PATTERN, LombokUtils.DEPRECATED_PATTERN);
+      PsiModifierList methodParameterModifierList = methodParameter.getModifierList();
+      copyAnnotations(psiField, methodParameterModifierList,
+          LombokUtils.NON_NULL_PATTERN, LombokUtils.NULLABLE_PATTERN, LombokUtils.DEPRECATED_PATTERN);
+      addOnXAnnotations(witherAnnotation, methodParameterModifierList, "onParam");
       result.withParameter(methodParameter);
 
       final String paramString = getConstructorCall(psiField, psiFieldContainingClass);

--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/util/LombokProcessorUtil.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/util/LombokProcessorUtil.java
@@ -1,6 +1,8 @@
 package de.plushnikov.intellij.plugin.util;
 
 import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiAnnotationMemberValue;
+import com.intellij.psi.PsiAnnotationParameterList;
 import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiModifierList;
 import com.intellij.psi.PsiModifierListOwner;
@@ -10,6 +12,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,6 +31,21 @@ public class LombokProcessorUtil {
   @Nullable
   public static String getAccessVisibility(@NotNull PsiAnnotation psiAnnotation) {
     return convertAccessLevelToJavaModifier(PsiAnnotationUtil.getStringAnnotationValue(psiAnnotation, "access"));
+  }
+  
+  @NotNull
+  public static Collection<String> getOnX(@NotNull PsiAnnotation psiAnnotation, @NotNull String parameterName) {
+    PsiAnnotationMemberValue onXValue = psiAnnotation.findAttributeValue(parameterName);
+    if (!(onXValue instanceof PsiAnnotation)) {
+      return Collections.emptyList();
+    }
+    Collection<PsiAnnotation> annotations = PsiAnnotationUtil.getAnnotationValues((PsiAnnotation) onXValue, "value", PsiAnnotation.class);
+    Collection<String> annotationStrings = new ArrayList<String>();
+    for (PsiAnnotation annotation : annotations) {
+      PsiAnnotationParameterList params = annotation.getParameterList();
+      annotationStrings.add(PsiAnnotationUtil.getSimpleNameOf(annotation) + params.getText());
+    }
+    return annotationStrings;
   }
 
   @Nullable

--- a/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/util/PsiAnnotationUtil.java
+++ b/lombok-plugin/src/main/java/de/plushnikov/intellij/plugin/util/PsiAnnotationUtil.java
@@ -169,6 +169,10 @@ public class PsiAnnotationUtil {
       if (asClass.isAssignableFrom(PsiType.class)) {
         value = (T) elementValue.getType();
       }
+    } else if (psiElement instanceof PsiAnnotation) {
+      if (asClass.isAssignableFrom(PsiAnnotation.class)) {
+        value = (T) psiElement;
+      }
     }
     return value;
   }


### PR DESCRIPTION
Hi!

There were a lot of false positive errors in my workspace from combining Lombok constructors with constructor injection, so I implemented onX support in your plugin. I hope it'll also be useful for everyone currently +1-ing Issue #47 :)

These commits will suppress the errors from using the onConstructor/onMethod/onParam parameters, and will also cause the annotations to be added to the generated methods when Delomboking.
