### PR TITLE
Removed commons lang dependency to make jar a little bit smaller

### DIFF
--- a/patcher/build.gradle
+++ b/patcher/build.gradle
@@ -6,8 +6,6 @@ dependencies {
 
     compile 'org.javassist:javassist:3.20.0-GA'
 
-    compile 'org.apache.commons:commons-lang3:3.4'
-
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/patcher/src/main/java/de/plushnikov/intellij/lombok/patcher/inject/LiveInjector.java
+++ b/patcher/src/main/java/de/plushnikov/intellij/lombok/patcher/inject/LiveInjector.java
@@ -22,7 +22,7 @@
 package de.plushnikov.intellij.lombok.patcher.inject;
 
 import com.sun.tools.attach.VirtualMachine;
-import org.apache.commons.lang3.StringUtils;
+import de.plushnikov.intellij.util.StringUtils;
 
 import java.io.File;
 import java.lang.management.ManagementFactory;

--- a/patcher/src/main/java/de/plushnikov/intellij/plugin/agent/IdeaPatcherOptionsHolder.java
+++ b/patcher/src/main/java/de/plushnikov/intellij/plugin/agent/IdeaPatcherOptionsHolder.java
@@ -1,7 +1,5 @@
 package de.plushnikov.intellij.plugin.agent;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -30,8 +28,8 @@ public class IdeaPatcherOptionsHolder {
       return;
     }
 
-    for (String argString : StringUtils.split(args, ",")) {
-      String[] argKeyValue = StringUtils.split(argString, "=");
+    for (String argString : args.split(",")) {
+      String[] argKeyValue = argString.split("=");
       if (argKeyValue.length == 2) {
         options.put(argKeyValue[0], argKeyValue[1]);
       }

--- a/patcher/src/main/java/de/plushnikov/intellij/plugin/agent/support/BuildNumber.java
+++ b/patcher/src/main/java/de/plushnikov/intellij/plugin/agent/support/BuildNumber.java
@@ -16,7 +16,7 @@
 
 package de.plushnikov.intellij.plugin.agent.support;
 
-import org.apache.commons.lang3.StringUtils;
+import de.plushnikov.intellij.util.StringUtils;
 
 /**
  * @author max

--- a/patcher/src/main/java/de/plushnikov/intellij/plugin/agent/transformer/AbstractBuildDependentTransformer.java
+++ b/patcher/src/main/java/de/plushnikov/intellij/plugin/agent/transformer/AbstractBuildDependentTransformer.java
@@ -3,7 +3,7 @@ package de.plushnikov.intellij.plugin.agent.transformer;
 import de.plushnikov.intellij.plugin.agent.IdeaPatcherOptionsHolder;
 import de.plushnikov.intellij.plugin.agent.support.BuildNumber;
 import de.plushnikov.intellij.plugin.agent.support.SupportedBuild;
-import org.apache.commons.lang3.StringUtils;
+import de.plushnikov.intellij.util.StringUtils;
 
 /**
  * @author Alexej Kubarev

--- a/patcher/src/main/java/de/plushnikov/intellij/util/StringUtils.java
+++ b/patcher/src/main/java/de/plushnikov/intellij/util/StringUtils.java
@@ -1,0 +1,27 @@
+package de.plushnikov.intellij.util;
+
+import java.util.Collection;
+
+public class StringUtils {
+  public static boolean isEmpty(String str) {
+    return str == null || str.length() == 0;
+  }
+
+  public static boolean isNotEmpty(String str) {
+    return !isEmpty(str);
+  }
+
+  public static String join(Collection<String> list, String conjunction) {
+    StringBuilder sb = new StringBuilder();
+    boolean first = true;
+    for (String item : list) {
+      if (first) {
+        first = false;
+      } else {
+        sb.append(conjunction);
+      }
+      sb.append(item);
+    }
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
I think we don't really need full commons lang dependency in the jar.

It also looks like javassist is present twice in the lombok-plugin.zip distribution and repackaged in the agent.jar. I'll try to clean it too:)