### PR TITLE
Adding notification support for project setup issues

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponent.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponent.java
@@ -1,0 +1,73 @@
+package de.plushnikov.intellij.plugin;
+
+import com.intellij.compiler.CompilerConfiguration;
+import com.intellij.compiler.options.AnnotationProcessorsConfigurable;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationListener;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.components.AbstractProjectComponent;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.project.Project;
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.event.HyperlinkEvent;
+
+/**
+ * Shows notifications about project setup issues, that make the plugin not working.
+ * @author Alexej Kubarev
+ */
+public class LombokPluginProjectValidatorComponent extends AbstractProjectComponent {
+
+  private Project project;
+
+  public LombokPluginProjectValidatorComponent(Project project) {
+
+    super(project);
+    this.project = project;
+
+  }
+
+  @NotNull
+  @Override
+  public String getComponentName() {
+
+    return "lombok.ProjectValidatiorComponent";
+  }
+
+  @Override
+  public void projectOpened() {
+
+    CompilerConfiguration config = CompilerConfiguration.getInstance(project);
+    boolean enabled = config.isAnnotationProcessorsEnabled();
+
+    if (!enabled) {
+      NotificationGroup group = new NotificationGroup("Lombok Plugin", NotificationDisplayType.BALLOON, true);
+      Notification notification = group.createNotification(LombokBundle.message("config.warn.annotation-processing.disabled.title", ""),
+          LombokBundle.message("config.warn.annotation-processing.disabled.message", project.getName()),
+          NotificationType.ERROR,
+          new SettingsOpeningListener(project));
+
+      Notifications.Bus.notify(notification);
+    }
+  }
+
+  private static class SettingsOpeningListener extends NotificationListener.Adapter {
+
+    private Project project;
+
+    public SettingsOpeningListener(Project project) {
+      this.project = project;
+    }
+
+    @Override
+    protected void hyperlinkActivated(@NotNull final Notification notification, @NotNull final HyperlinkEvent e) {
+
+      ShowSettingsUtil.getInstance()
+          .showSettingsDialog(project, new AnnotationProcessorsConfigurable(project).getDisplayName());
+    }
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -61,6 +61,7 @@
   <project-components>
     <component>
       <implementation-class>de.plushnikov.intellij.plugin.LombokPluginUpdateProjectComponent</implementation-class>
+      <implementation-class>de.plushnikov.intellij.plugin.LombokPluginProjectValidatorComponent</implementation-class>
     </component>
   </project-components>
 

--- a/src/main/resources/messages/lombokBundle.properties
+++ b/src/main/resources/messages/lombokBundle.properties
@@ -1,3 +1,11 @@
+config.warn.annotation-processing.disabled.title=Lombok Requires Annotation Processing
+config.warn.annotation-processing.disabled.message=<br />\
+  Annotation processing seems to be disabled for the project {0}.<br />\
+  For  plugin to function correctly, please enable it under<br />\
+  "Settings > Build > Compiler > Annotation Processors"<br />\
+  <br />\
+  <a href="#">Click on this notification to go to Settings now.</a>
+
 daemon.donate.title=Lombok support plugin updated to v{0}
 daemon.donate.content=\
 - Added support for transparent changing of visibility of existing fields and variables<br/>\


### PR DESCRIPTION
More and more issues (like #213)  come in about Lombok Plugin not working that boils down to AnnotationProcessing being disabled or dependency missing.

This is an initial step for doing on-the-fly detection of the issues with project setup.
Currently only supports checking for annotation processing being enabled.

What do you think?

This is a followup on the idea mentioned in #215 about actively notifying users.