### PR TITLE
Missing Lombok dependency check

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponent.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponent.java
@@ -2,6 +2,7 @@ package de.plushnikov.intellij.plugin;
 
 import com.intellij.compiler.CompilerConfiguration;
 import com.intellij.compiler.options.AnnotationProcessorsConfigurable;
+import com.intellij.execution.configurations.SearchScopeProvider;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationDisplayType;
 import com.intellij.notification.NotificationGroup;
@@ -9,10 +10,23 @@ import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.components.AbstractProjectComponent;
+import com.intellij.openapi.externalSystem.model.project.ModuleDependencyData;
+import com.intellij.openapi.externalSystem.service.project.manage.ModuleDependencyDataService;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.roots.LibraryOrderEntry;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.impl.libraries.LibraryImpl;
+import com.intellij.openapi.roots.libraries.Library;
+import com.intellij.openapi.roots.libraries.LibraryTable;
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.PsiFileFactory;
+import com.intellij.psi.PsiPackage;
 import de.plushnikov.intellij.plugin.settings.ProjectSettings;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,37 +54,83 @@ public class LombokPluginProjectValidatorComponent extends AbstractProjectCompon
 
   @Override
   public void projectOpened() {
+
+    // If plugin is not enabled - no point to continue
+    if (!ProjectSettings.isLombokEnabledInProject(project)) {
+      return;
+    }
+
+    NotificationGroup group = new NotificationGroup("Lombok Plugin", NotificationDisplayType.BALLOON, true);
+
+    // Lombok dependency check
+    boolean hasLombokLibrary = hasLombokLibrary(project);
+    if (!hasLombokLibrary) {
+      Notification notification = group.createNotification(LombokBundle.message("config.warn.dependency.missing.title", ""),
+          LombokBundle.message("config.warn.dependency.missing.message", project.getName()),
+          NotificationType.ERROR,
+          new NotificationListener.UrlOpeningListener(false));
+
+      Notifications.Bus.notify(notification, project);
+    }
+
+    // Annotation Processing check
+    boolean annotationProcessorsEnabled = hasAnnotationProcessorsEnabled(project, true);
+    if (!annotationProcessorsEnabled) {
+
+      String annotationProcessorsConfigName = new AnnotationProcessorsConfigurable(project).getDisplayName();
+
+      Notification notification = group.createNotification(LombokBundle.message("config.warn.annotation-processing.disabled.title", ""),
+          LombokBundle.message("config.warn.annotation-processing.disabled.message", project.getName()),
+          NotificationType.ERROR,
+          new SettingsOpeningListener(project, annotationProcessorsConfigName));
+
+      Notifications.Bus.notify(notification, project);
+    }
+
+
+  }
+
+  private boolean hasAnnotationProcessorsEnabled(Project project, boolean checkModules) {
     final CompilerConfiguration config = CompilerConfiguration.getInstance(project);
     boolean enabled = config.isAnnotationProcessorsEnabled();
+
+    if (!checkModules) {
+      return enabled;
+    }
 
     final ModuleManager moduleManager = ModuleManager.getInstance(project);
     for (Module module : moduleManager.getModules()) {
       enabled &= config.getAnnotationProcessingConfiguration(module).isEnabled();
+
     }
 
-    if (!enabled && ProjectSettings.isLombokEnabledInProject(project)) {
-      NotificationGroup group = new NotificationGroup("Lombok Plugin", NotificationDisplayType.BALLOON, true);
-      Notification notification = group.createNotification(LombokBundle.message("config.warn.annotation-processing.disabled.title", ""),
-          LombokBundle.message("config.warn.annotation-processing.disabled.message", project.getName()),
-          NotificationType.ERROR,
-          new SettingsOpeningListener(project));
-
-      Notifications.Bus.notify(notification);
-    }
+    return enabled;
   }
 
+  private boolean hasLombokLibrary(Project project) {
+
+    PsiPackage lombokPackage = JavaPsiFacade.getInstance(project).findPackage("lombok");
+
+    return lombokPackage != null;
+  }
+
+  /**
+   * Simple {@link NotificationListener.Adapter} that opens Settings Page for correct dialog.
+   */
   private static class SettingsOpeningListener extends NotificationListener.Adapter {
 
     private Project project;
+    private String nameToSelect;
 
-    public SettingsOpeningListener(Project project) {
+    public SettingsOpeningListener(Project project, String nameToSelect) {
       this.project = project;
+      this.nameToSelect = nameToSelect;
     }
 
     @Override
     protected void hyperlinkActivated(@NotNull final Notification notification, @NotNull final HyperlinkEvent e) {
       ShowSettingsUtil.getInstance()
-          .showSettingsDialog(project, new AnnotationProcessorsConfigurable(project).getDisplayName());
+          .showSettingsDialog(project, nameToSelect);
     }
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponent.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponent.java
@@ -2,7 +2,6 @@ package de.plushnikov.intellij.plugin;
 
 import com.intellij.compiler.CompilerConfiguration;
 import com.intellij.compiler.options.AnnotationProcessorsConfigurable;
-import com.intellij.execution.configurations.SearchScopeProvider;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationDisplayType;
 import com.intellij.notification.NotificationGroup;
@@ -10,27 +9,21 @@ import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.components.AbstractProjectComponent;
-import com.intellij.openapi.externalSystem.model.project.ModuleDependencyData;
-import com.intellij.openapi.externalSystem.service.project.manage.ModuleDependencyDataService;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
-import com.intellij.openapi.roots.LibraryOrderEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.impl.libraries.LibraryImpl;
-import com.intellij.openapi.roots.libraries.Library;
-import com.intellij.openapi.roots.libraries.LibraryTable;
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
-import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.roots.OrderEntry;
 import com.intellij.psi.JavaPsiFacade;
-import com.intellij.psi.PsiFileFactory;
 import com.intellij.psi.PsiPackage;
 import de.plushnikov.intellij.plugin.settings.ProjectSettings;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.event.HyperlinkEvent;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Shows notifications about project setup issues, that make the plugin not working.
@@ -49,23 +42,22 @@ public class LombokPluginProjectValidatorComponent extends AbstractProjectCompon
   @NotNull
   @Override
   public String getComponentName() {
-    return "lombok.ProjectValidatiorComponent";
+    return "lombok.ProjectValidatorComponent";
   }
 
   @Override
   public void projectOpened() {
-
     // If plugin is not enabled - no point to continue
     if (!ProjectSettings.isLombokEnabledInProject(project)) {
       return;
     }
 
-    NotificationGroup group = new NotificationGroup("Lombok Plugin", NotificationDisplayType.BALLOON, true);
+    NotificationGroup group = new NotificationGroup(Version.PLUGIN_NAME, NotificationDisplayType.BALLOON, true);
 
     // Lombok dependency check
     boolean hasLombokLibrary = hasLombokLibrary(project);
     if (!hasLombokLibrary) {
-      Notification notification = group.createNotification(LombokBundle.message("config.warn.dependency.missing.title", ""),
+      Notification notification = group.createNotification(LombokBundle.message("config.warn.dependency.missing.title"),
           LombokBundle.message("config.warn.dependency.missing.message", project.getName()),
           NotificationType.ERROR,
           new NotificationListener.UrlOpeningListener(false));
@@ -73,45 +65,99 @@ public class LombokPluginProjectValidatorComponent extends AbstractProjectCompon
       Notifications.Bus.notify(notification, project);
     }
 
+    if (hasLombokLibrary) {
+      final ModuleManager moduleManager = ModuleManager.getInstance(project);
+      for (Module module : moduleManager.getModules()) {
+        final OrderEntry lombokEntry = findLombokEntry(ModuleRootManager.getInstance(module));
+        final String lombokVersion = parseLombokVersion(lombokEntry);
+
+        if (null != lombokVersion && compareVersionString(lombokVersion, Version.LAST_LOMBOK_VERSION) < 0) {
+          Notification notification = group.createNotification(LombokBundle.message("config.warn.dependency.outdated.title"),
+              LombokBundle.message("config.warn.dependency.outdated.message", project.getName(), module.getName(), lombokVersion, Version.LAST_LOMBOK_VERSION),
+              NotificationType.WARNING, null);
+
+          Notifications.Bus.notify(notification, project);
+        }
+      }
+    }
+
     // Annotation Processing check
-    boolean annotationProcessorsEnabled = hasAnnotationProcessorsEnabled(project, true);
+    boolean annotationProcessorsEnabled = hasAnnotationProcessorsEnabled(project);
     if (!annotationProcessorsEnabled) {
 
       String annotationProcessorsConfigName = new AnnotationProcessorsConfigurable(project).getDisplayName();
 
-      Notification notification = group.createNotification(LombokBundle.message("config.warn.annotation-processing.disabled.title", ""),
+      Notification notification = group.createNotification(LombokBundle.message("config.warn.annotation-processing.disabled.title"),
           LombokBundle.message("config.warn.annotation-processing.disabled.message", project.getName()),
           NotificationType.ERROR,
           new SettingsOpeningListener(project, annotationProcessorsConfigName));
 
       Notifications.Bus.notify(notification, project);
     }
-
-
   }
 
-  private boolean hasAnnotationProcessorsEnabled(Project project, boolean checkModules) {
+  private boolean hasAnnotationProcessorsEnabled(Project project) {
     final CompilerConfiguration config = CompilerConfiguration.getInstance(project);
-    boolean enabled = config.isAnnotationProcessorsEnabled();
-
-    if (!checkModules) {
-      return enabled;
-    }
+    boolean enabled = true;
 
     final ModuleManager moduleManager = ModuleManager.getInstance(project);
     for (Module module : moduleManager.getModules()) {
-      enabled &= config.getAnnotationProcessingConfiguration(module).isEnabled();
-
+      if (ModuleRootManager.getInstance(module).getSourceRoots().length > 0) {
+        enabled &= config.getAnnotationProcessingConfiguration(module).isEnabled();
+      }
     }
 
     return enabled;
   }
 
   private boolean hasLombokLibrary(Project project) {
-
     PsiPackage lombokPackage = JavaPsiFacade.getInstance(project).findPackage("lombok");
 
     return lombokPackage != null;
+  }
+
+  @Nullable
+  private OrderEntry findLombokEntry(@NotNull ModuleRootManager moduleRootManager) {
+    final OrderEntry[] orderEntries = moduleRootManager.getOrderEntries();
+    for (OrderEntry orderEntry : orderEntries) {
+      if (orderEntry.getPresentableName().contains("lombok")) {
+        return orderEntry;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  protected String parseLombokVersion(@Nullable OrderEntry orderEntry) {
+    String result = null;
+    if (null != orderEntry) {
+      final String presentableName = orderEntry.getPresentableName();
+      Pattern pattern = Pattern.compile("(.*:)([\\d\\.]+)(.*)");
+      final Matcher matcher = pattern.matcher(presentableName);
+      if (matcher.find()) {
+        result = matcher.group(2);
+      }
+    }
+    return result;
+  }
+
+  protected int compareVersionString(@NotNull String firstVersionOne, @NotNull String secondVersion) {
+    String[] firstVersionParts = firstVersionOne.split("\\.");
+    String[] secondVersionParts = secondVersion.split("\\.");
+    int length = Math.max(firstVersionParts.length, secondVersionParts.length);
+    for (int i = 0; i < length; i++) {
+      int firstPart = i < firstVersionParts.length && !firstVersionParts[i].isEmpty() ?
+          Integer.parseInt(firstVersionParts[i]) : 0;
+      int secondPart = i < secondVersionParts.length && !secondVersionParts[i].isEmpty() ?
+          Integer.parseInt(secondVersionParts[i]) : 0;
+      if (firstPart < secondPart) {
+        return -1;
+      }
+      if (firstPart > secondPart) {
+        return 1;
+      }
+    }
+    return 0;
   }
 
   /**
@@ -119,18 +165,17 @@ public class LombokPluginProjectValidatorComponent extends AbstractProjectCompon
    */
   private static class SettingsOpeningListener extends NotificationListener.Adapter {
 
-    private Project project;
-    private String nameToSelect;
+    private final Project project;
+    private final String nameToSelect;
 
-    public SettingsOpeningListener(Project project, String nameToSelect) {
+    SettingsOpeningListener(Project project, String nameToSelect) {
       this.project = project;
       this.nameToSelect = nameToSelect;
     }
 
     @Override
     protected void hyperlinkActivated(@NotNull final Notification notification, @NotNull final HyperlinkEvent e) {
-      ShowSettingsUtil.getInstance()
-          .showSettingsDialog(project, nameToSelect);
+      ShowSettingsUtil.getInstance().showSettingsDialog(project, nameToSelect);
     }
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/LombokPluginUpdateProjectComponent.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/LombokPluginUpdateProjectComponent.java
@@ -35,7 +35,7 @@ public class LombokPluginUpdateProjectComponent implements ProjectComponent {
     if (application.isUpdated() && !application.isUpdateNotificationShown()) {
       application.setUpdateNotificationShown(true);
 
-      NotificationGroup group = new NotificationGroup("Lombok plugin", NotificationDisplayType.STICKY_BALLOON, true);
+      NotificationGroup group = new NotificationGroup(Version.PLUGIN_NAME, NotificationDisplayType.STICKY_BALLOON, true);
       Notification notification = group.createNotification(
           LombokBundle.message("daemon.donate.title", Version.PLUGIN_VERSION),
           LombokBundle.message("daemon.donate.content"),

--- a/src/main/java/de/plushnikov/intellij/plugin/Version.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/Version.java
@@ -1,8 +1,10 @@
 package de.plushnikov.intellij.plugin;
 
 public interface Version {
+  String PLUGIN_NAME = "Lombok plugin";
   /**
    * Current plugin version.
    */
   String PLUGIN_VERSION = "0.12";
+  String LAST_LOMBOK_VERSION = "1.16.8";
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/settings/ProjectSettingsPage.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/settings/ProjectSettingsPage.java
@@ -4,6 +4,7 @@ import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SearchableConfigurable;
+import de.plushnikov.intellij.plugin.Version;
 import de.plushnikov.intellij.plugin.provider.LombokProcessorProvider;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -40,7 +41,7 @@ public class ProjectSettingsPage implements SearchableConfigurable, Configurable
   @Nls
   @Override
   public String getDisplayName() {
-    return "Lombok plugin";
+    return Version.PLUGIN_NAME;
   }
 
   @Nullable

--- a/src/main/resources/messages/lombokBundle.properties
+++ b/src/main/resources/messages/lombokBundle.properties
@@ -1,21 +1,29 @@
+config.warn.dependency.missing.title=Lombok Dependency is missing
+config.warn.dependency.missing.message=<br>\
+  Project "{0}" does not seem to have lombok dependency added.<br>\
+  This plugin <b>does not</b> provide it and will not function correctly without.<br>\
+  Please make sure to add it manually and refresh your project.<br>\
+  <br>\
+  <b><a href="https://projectlombok.org/mavenrepo/index.html">Click here to see how to add it to your project.</a></b>
+
 config.warn.annotation-processing.disabled.title=Lombok Requires Annotation Processing
-config.warn.annotation-processing.disabled.message=<br />\
-  Annotation processing seems to be disabled for the project {0}.<br />\
-  For  plugin to function correctly, please enable it under<br />\
-  "Settings > Build > Compiler > Annotation Processors"<br />\
-  <br />\
-  <a href="#">Click on this notification to go to Settings now.</a>
+config.warn.annotation-processing.disabled.message=<br>\
+  Annotation processing seems to be disabled for the project "{0}".<br>\
+  For  plugin to function correctly, please enable it under<br>\
+  "Settings > Build > Compiler > Annotation Processors"<br>\
+  <br>\
+  <b><a href="#">Click on this notification to go to Settings now.</a></b>
 
 daemon.donate.title=Lombok support plugin updated to v{0}
 daemon.donate.content=\
-- Added support for transparent changing of visibility of existing fields and variables<br/>\
-- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/56">#56</a>): Missing auto-generated modifiers on fields and class shown in the "Structure" window when using `@Value`<br/>\
-- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/137">#137</a>): Private visibility added by @Value not respected by IDE.<br/>\
-- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/147">#147</a>): @FieldDefaults(makeFinal = true) and bitwise operators produce an error message<br/>\
-- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/158">#158</a>): val causes intellij to show an invalid error when used alongside an anonymous class<br/>\
-- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/202">#202</a>): @Builder supports setter for final field (@Value)<br/>\
-  <br/>\
+- Added support for transparent changing of visibility of existing fields and variables<br>\
+- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/56">#56</a>): Missing auto-generated modifiers on fields and class shown in the "Structure" window when using `@Value`<br>\
+- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/137">#137</a>): Private visibility added by @Value not respected by IDE.<br>\
+- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/147">#147</a>): @FieldDefaults(makeFinal = true) and bitwise operators produce an error message<br>\
+- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/158">#158</a>): val causes intellij to show an invalid error when used alongside an anonymous class<br>\
+- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/202">#202</a>): @Builder supports setter for final field (@Value)<br>\
+  <br>\
   <span style="font-size: 150%">If you find my plugin helpful, donate me using \
-  <br/><b>\
+  <br><b>\
   <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick\\&hosted_button_id=3F9HXD7A2SMCN">PayPal</a>\
   </b></span>

--- a/src/main/resources/messages/lombokBundle.properties
+++ b/src/main/resources/messages/lombokBundle.properties
@@ -13,11 +13,17 @@ config.warn.annotation-processing.disabled.message=<br>\
   "Settings > Build > Compiler > Annotation Processors"<br>\
   <br>\
   <b><a href="#">Click on this notification to go to Settings now.</a></b>
+config.warn.dependency.outdated.title=Lombok Dependency is possible outdated
+config.warn.dependency.outdated.message=<br>\
+  Project "{0}" and Module "{1}" seem to have outdated lombok dependency added.<br>\
+  Configured version "{2}", but there is at least version "{3}" already released<br>\
+  Maybe you want to update? <br>
 
 daemon.donate.title=Lombok support plugin updated to v{0}
 daemon.donate.content=\
 - Added support for transparent changing of visibility of existing fields and variables<br>\
 - Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/56">#56</a>): Missing auto-generated modifiers on fields and class shown in the "Structure" window when using `@Value`<br>\
+- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/103">#103</a>): Lombok plugin should tell developer that old lombok.jar is used on classpath<br>\
 - Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/137">#137</a>): Private visibility added by @Value not respected by IDE.<br>\
 - Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/147">#147</a>): @FieldDefaults(makeFinal = true) and bitwise operators produce an error message<br>\
 - Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/158">#158</a>): val causes intellij to show an invalid error when used alongside an anonymous class<br>\

--- a/src/test/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponentTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponentTest.java
@@ -1,0 +1,75 @@
+package de.plushnikov.intellij.plugin;
+
+import com.intellij.openapi.roots.OrderEntry;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LombokPluginProjectValidatorComponentTest {
+
+  private LombokPluginProjectValidatorComponent component;
+  private OrderEntry orderEntry;
+
+  @Before
+  public void setUp() throws Exception {
+    component = new LombokPluginProjectValidatorComponent(null);
+    orderEntry = mock(OrderEntry.class);
+  }
+
+  @Test
+  public void parseLombokVersionFromGradle() throws Exception {
+    when(orderEntry.getPresentableName()).thenReturn("Gradle: org.projectlombok:lombok:1.16.8");
+    assertEquals("1.16.8", component.parseLombokVersion(orderEntry));
+  }
+
+  @Test
+  public void parseLombokVersionFromMaven() throws Exception {
+    when(orderEntry.getPresentableName()).thenReturn("Maven: org.projectlombok:lombok:1.16.6");
+    assertEquals("1.16.6", component.parseLombokVersion(orderEntry));
+  }
+
+  @Test
+  public void parseLombokVersionFromUnknown() throws Exception {
+    when(orderEntry.getPresentableName()).thenReturn("lombok");
+    assertNull(component.parseLombokVersion(orderEntry));
+  }
+
+  @Test
+  public void compareVersionString1_2() throws Exception {
+    assertEquals(-1, component.compareVersionString("1", "2"));
+  }
+
+  @Test
+  public void compareVersionString__2() throws Exception {
+    assertEquals(-1, component.compareVersionString("", "2"));
+  }
+
+  @Test
+  public void compareVersionString123_121() throws Exception {
+    assertEquals(1, component.compareVersionString("1.2.3", "1.2.1"));
+  }
+
+  @Test
+  public void compareVersionString1166_1168() throws Exception {
+    assertEquals(-1, component.compareVersionString("1.16.6", "1.16.8"));
+  }
+
+  @Test
+  public void compareVersionString1168_1168() throws Exception {
+    assertEquals(0, component.compareVersionString("1.16.8", "1.16.8"));
+  }
+
+  @Test
+  public void compareVersionString0102_1168() throws Exception {
+    assertEquals(-1, component.compareVersionString("0.10.2", "1.16.8"));
+  }
+
+  @Test
+  public void compareVersionString1169_1168() throws Exception {
+    assertEquals(1, component.compareVersionString("1.16.9", "1.16.8"));
+  }
+}


### PR DESCRIPTION
A followup on the project configuration issues detection.

Fixes #103 in a sense that it checks if lombok is missing or not.

Also modified bundle to use `<br>` instead of `<br/>` as the latter seems to break Event Log (no new lines). This is done according to https://github.com/JetBrains/intellij-community/blob/85ea85748fade65fee11c6fe18f10264a810009e/plugins/gradle/resources/i18n/GradleBundle.properties as a reference where new lines are correctly shown in event log.

Im personally not convinced that annotation processing needs to be done on modules as well, but i guess it doesn't hurt. For the sake of ease of switching it on and off - small refactoring of the code.