### PR TITLE
Improvements to warnings introduced in 0.12

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponent.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponent.java
@@ -17,13 +17,15 @@ import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.OrderEntry;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiPackage;
-import de.plushnikov.intellij.plugin.settings.ProjectSettings;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.event.HyperlinkEvent;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.swing.event.HyperlinkEvent;
+
+import de.plushnikov.intellij.plugin.settings.ProjectSettings;
 
 /**
  * Shows notifications about project setup issues, that make the plugin not working.
@@ -56,7 +58,7 @@ public class LombokPluginProjectValidatorComponent extends AbstractProjectCompon
 
     // Lombok dependency check
     boolean hasLombokLibrary = hasLombokLibrary(project);
-    if (!hasLombokLibrary) {
+    if (!hasLombokLibrary && ProjectSettings.isEnabled(project, ProjectSettings.IS_MISSING_LOMBOK_CHECK_ENABLED)) {
       Notification notification = group.createNotification(LombokBundle.message("config.warn.dependency.missing.title"),
           LombokBundle.message("config.warn.dependency.missing.message", project.getName()),
           NotificationType.ERROR, NotificationListener.URL_OPENING_LISTENER);

--- a/src/main/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponent.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/LombokPluginProjectValidatorComponent.java
@@ -58,7 +58,9 @@ public class LombokPluginProjectValidatorComponent extends AbstractProjectCompon
 
     // Lombok dependency check
     boolean hasLombokLibrary = hasLombokLibrary(project);
-    if (!hasLombokLibrary && ProjectSettings.isEnabled(project, ProjectSettings.IS_MISSING_LOMBOK_CHECK_ENABLED)) {
+
+    // If dependency is missing and missing dependency notification setting is enabled (defaults to disabled)
+    if (!hasLombokLibrary && ProjectSettings.isEnabled(project, ProjectSettings.IS_MISSING_LOMBOK_CHECK_ENABLED, false)) {
       Notification notification = group.createNotification(LombokBundle.message("config.warn.dependency.missing.title"),
           LombokBundle.message("config.warn.dependency.missing.message", project.getName()),
           NotificationType.ERROR, NotificationListener.URL_OPENING_LISTENER);
@@ -66,7 +68,8 @@ public class LombokPluginProjectValidatorComponent extends AbstractProjectCompon
       Notifications.Bus.notify(notification, project);
     }
 
-    if (hasLombokLibrary && ProjectSettings.isEnabled(project, ProjectSettings.IS_LOMBOK_VERSION_CHECK_ENABLED)) {
+    // If dependency is present and out of date notification setting is enabled (defaults to disabled)
+    if (hasLombokLibrary && ProjectSettings.isEnabled(project, ProjectSettings.IS_LOMBOK_VERSION_CHECK_ENABLED, false)) {
       final ModuleManager moduleManager = ModuleManager.getInstance(project);
       for (Module module : moduleManager.getModules()) {
         String lombokVersion = parseLombokVersion(findLombokEntry(ModuleRootManager.getInstance(module)));

--- a/src/main/java/de/plushnikov/intellij/plugin/settings/ProjectSettings.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/settings/ProjectSettings.java
@@ -18,6 +18,7 @@ public class ProjectSettings {
 
   public static final String IS_RUNTIME_PATCH_ENABLED = PREFIX + "IS_RUNTIME_PATCH_Enabled";
   public static final String IS_LOMBOK_VERSION_CHECK_ENABLED = PREFIX + "IS_LOMBOK_VERSION_CHECK_Enabled";
+  public static final String IS_MISSING_LOMBOK_CHECK_ENABLED = PREFIX + "IS_MISSING_LOMBOK_CHECK_Enabled";
 
   public static boolean isLombokEnabledInProject(@NotNull final Project project) {
     return isEnabled(project, LOMBOK_ENABLED_IN_PROJECT);

--- a/src/main/java/de/plushnikov/intellij/plugin/settings/ProjectSettings.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/settings/ProjectSettings.java
@@ -32,6 +32,10 @@ public class ProjectSettings {
     return isEnabled(PropertiesComponent.getInstance(project), propertyName);
   }
 
+  public static boolean isEnabled(@NotNull Project project, final String propertyName, boolean defaultValue) {
+    return isEnabled(PropertiesComponent.getInstance(project), propertyName, defaultValue);
+  }
+
   public static boolean isEnabled(PropertiesComponent properties, String propertyName) {
     return isEnabled(properties, propertyName, true);
   }

--- a/src/main/java/de/plushnikov/intellij/plugin/settings/ProjectSettingsPage.form
+++ b/src/main/java/de/plushnikov/intellij/plugin/settings/ProjectSettingsPage.form
@@ -138,7 +138,7 @@
           </hspacer>
         </children>
       </grid>
-      <grid id="7cbc9" binding="mySettingsPanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="7cbc9" binding="mySettingsPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -159,6 +159,16 @@
               <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
+          <hspacer id="b8e3e">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <hspacer id="6d705">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
           <component id="35112" class="javax.swing.JCheckBox" binding="myEnableLombokVersionWarning">
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -169,9 +179,17 @@
           </component>
           <vspacer id="4ed48">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
           </vspacer>
+          <component id="30814" class="javax.swing.JCheckBox" binding="myMissingLombokWarning">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Enable missing lombok dependency warning (for entire project)"/>
+            </properties>
+          </component>
         </children>
       </grid>
     </children>

--- a/src/main/java/de/plushnikov/intellij/plugin/settings/ProjectSettingsPage.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/settings/ProjectSettingsPage.java
@@ -4,15 +4,20 @@ import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SearchableConfigurable;
-import de.plushnikov.intellij.plugin.Version;
-import de.plushnikov.intellij.plugin.provider.LombokProcessorProvider;
+
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javax.swing.Icon;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+
+import de.plushnikov.intellij.plugin.Version;
+import de.plushnikov.intellij.plugin.provider.LombokProcessorProvider;
 
 public class ProjectSettingsPage implements SearchableConfigurable, Configurable.NoScroll {
 
@@ -31,6 +36,7 @@ public class ProjectSettingsPage implements SearchableConfigurable, Configurable
   private JPanel mySettingsPanel;
   private JCheckBox myEnableRuntimePatches;
   private JCheckBox myEnableLombokVersionWarning;
+  private JCheckBox myMissingLombokWarning;
   private JPanel mySupportPanel;
 
   private PropertiesComponent myPropertiesComponent;
@@ -97,6 +103,7 @@ public class ProjectSettingsPage implements SearchableConfigurable, Configurable
 
     myEnableRuntimePatches.setSelected(ProjectSettings.isEnabled(myPropertiesComponent, ProjectSettings.IS_RUNTIME_PATCH_ENABLED, false));
     myEnableLombokVersionWarning.setSelected(ProjectSettings.isEnabled(myPropertiesComponent, ProjectSettings.IS_LOMBOK_VERSION_CHECK_ENABLED, false));
+    myMissingLombokWarning.setSelected(ProjectSettings.isEnabled(myPropertiesComponent, ProjectSettings.IS_MISSING_LOMBOK_CHECK_ENABLED, false));
   }
 
   @Override
@@ -109,7 +116,8 @@ public class ProjectSettingsPage implements SearchableConfigurable, Configurable
         myEnableConstructorSupport.isSelected() != ProjectSettings.isEnabled(myPropertiesComponent, ProjectSettings.IS_CONSTRUCTOR_ENABLED) ||
         myEnableParcelableSupport.isSelected() != ProjectSettings.isEnabled(myPropertiesComponent, ProjectSettings.IS_THIRD_PARTY_ENABLED, false) ||
         myEnableRuntimePatches.isSelected() != ProjectSettings.isEnabled(myPropertiesComponent, ProjectSettings.IS_RUNTIME_PATCH_ENABLED, false) ||
-        myEnableLombokVersionWarning.isSelected() != ProjectSettings.isEnabled(myPropertiesComponent, ProjectSettings.IS_LOMBOK_VERSION_CHECK_ENABLED, false);
+        myEnableLombokVersionWarning.isSelected() != ProjectSettings.isEnabled(myPropertiesComponent, ProjectSettings.IS_LOMBOK_VERSION_CHECK_ENABLED, false) ||
+        myMissingLombokWarning.isSelected() != ProjectSettings.isEnabled(myPropertiesComponent, ProjectSettings.IS_MISSING_LOMBOK_CHECK_ENABLED, false);
   }
 
   @Override
@@ -127,6 +135,7 @@ public class ProjectSettingsPage implements SearchableConfigurable, Configurable
 
     ProjectSettings.setEnabled(myPropertiesComponent, ProjectSettings.IS_RUNTIME_PATCH_ENABLED, myEnableRuntimePatches.isSelected());
     ProjectSettings.setEnabled(myPropertiesComponent, ProjectSettings.IS_LOMBOK_VERSION_CHECK_ENABLED, myEnableLombokVersionWarning.isSelected());
+    ProjectSettings.setEnabled(myPropertiesComponent, ProjectSettings.IS_MISSING_LOMBOK_CHECK_ENABLED, myEnableLombokVersionWarning.isSelected());
     LombokSettings.getInstance().setEnableRuntimePatch(myEnableRuntimePatches.isSelected());
 
     myLombokProcessorProvider.initProcessors();


### PR DESCRIPTION
This allows disabling "missing lombok dependency" check completely for the entire project.
Additionally fixes issues with "disabled defaults" that are returning "enabled" state unless overwritten already.

This __does not__ solve the issue of the check not being smart enough to understand parent POM projects etc, but those with proper configuration can simply disable missing dependency check altogether.
