### PR TITLE
changed background LightImplementation of LightPsiClass

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip

--- a/src/main/java/de/plushnikov/intellij/plugin/action/delombok/BaseDelombokHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/action/delombok/BaseDelombokHandler.java
@@ -26,6 +26,7 @@ import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.psi.codeStyle.JavaCodeStyleManager;
 import de.plushnikov.intellij.plugin.processor.AbstractProcessor;
 import de.plushnikov.intellij.plugin.processor.ShouldGenerateFullCodeBlock;
+import de.plushnikov.intellij.plugin.psi.LombokLightClassBuilder;
 import de.plushnikov.intellij.plugin.settings.ProjectSettings;
 import de.plushnikov.intellij.plugin.util.PsiMethodUtil;
 import org.jetbrains.annotations.NotNull;
@@ -75,7 +76,10 @@ public class BaseDelombokHandler {
 
     if (processInnerClasses) {
       for (PsiClass innerClass : allInnerClasses) {
-        invoke(project, innerClass, processInnerClasses);
+        //skip our self generated classes
+        if (!(innerClass instanceof LombokLightClassBuilder)) {
+          invoke(project, innerClass, processInnerClasses);
+        }
       }
     }
     deleteAnnotations(processedAnnotations);

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/handler/BuilderHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/handler/BuilderHandler.java
@@ -305,7 +305,7 @@ public class BuilderHandler {
 
     LombokLightClassBuilder builderClass = createBuilderClass(psiClass, psiMethod, builderClassName,
       psiMethod.isConstructor() || psiMethod.hasModifierProperty(PsiModifier.STATIC), psiAnnotation);
-    builderClass.withConstructors(createConstructors(builderClass, psiAnnotation));
+    builderClass.withMethods(createConstructors(builderClass, psiAnnotation));
 
     final Collection<PsiParameter> builderParameters = getBuilderParameters(psiMethod, Collections.<PsiField>emptySet());
     final PsiSubstitutor builderSubstitutor = getBuilderSubstitutor(psiClass, builderClass);
@@ -320,7 +320,7 @@ public class BuilderHandler {
     final String builderClassName = getBuilderClassName(psiClass, psiAnnotation);
 
     LombokLightClassBuilder builderClass = createBuilderClass(psiClass, psiClass, builderClassName, true, psiAnnotation);
-    builderClass.withConstructors(createConstructors(builderClass, psiAnnotation));
+    builderClass.withMethods(createConstructors(builderClass, psiAnnotation));
 
     final AccessorsInfo accessorsInfo = AccessorsInfo.build(psiClass);
     final Collection<PsiField> psiFields = getBuilderFields(psiClass, Collections.<PsiField>emptySet(), accessorsInfo);
@@ -391,8 +391,7 @@ public class BuilderHandler {
   private LombokLightClassBuilder createBuilderClass(@NotNull PsiClass psiClass, @NotNull PsiTypeParameterListOwner psiTypeParameterListOwner, @NotNull String builderClassName, final boolean isStatic, @NotNull PsiAnnotation psiAnnotation) {
     final String builderClassQualifiedName = psiClass.getQualifiedName() + "." + builderClassName;
 
-    final Project project = psiClass.getProject();
-    final LombokLightClassBuilder classBuilder = new LombokLightClassBuilder(project, builderClassName, builderClassQualifiedName)
+    final LombokLightClassBuilder classBuilder = new LombokLightClassBuilder(psiClass, builderClassName, builderClassQualifiedName)
       .withContainingClass(psiClass)
       .withNavigationElement(psiAnnotation)
       .withParameterTypes(psiTypeParameterListOwner instanceof PsiMethod && ((PsiMethod) psiTypeParameterListOwner).isConstructor() ? psiClass.getTypeParameterList() : psiTypeParameterListOwner.getTypeParameterList())

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightClassBuilder.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightClassBuilder.java
@@ -1,143 +1,67 @@
 package de.plushnikov.intellij.plugin.psi;
 
-import com.intellij.lang.java.JavaLanguage;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiModifier;
 import com.intellij.psi.PsiTypeParameter;
 import com.intellij.psi.PsiTypeParameterList;
-import com.intellij.psi.impl.light.LightClass;
+import com.intellij.psi.impl.light.LightFieldBuilder;
+import com.intellij.psi.impl.light.LightPsiClassBuilder;
+import com.intellij.util.containers.ContainerUtil;
 import de.plushnikov.intellij.plugin.icon.LombokIcons;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.util.Arrays;
 import java.util.Collection;
 
-public class LombokLightClassBuilder extends LightClass {
-  private String myQualifiedName;
-  private PsiMethod[] myConstructors = new PsiMethod[0];
-  private PsiField[] myFields = new PsiField[0];
-  private PsiMethod[] myMethods = new PsiMethod[0];
-  private LombokLightModifierList myModifierList;
-  private PsiClass myContainingClass;
-  private PsiTypeParameterList myTypeParameterList;
-  private PsiTypeParameter[] myTypeParameters = new PsiTypeParameter[0];
+public class LombokLightClassBuilder extends LightPsiClassBuilder {
+  private final String myQualifiedName;
   private final Icon myBaseIcon;
+  private Collection<PsiField> myFields = ContainerUtil.newArrayList();
 
-  public LombokLightClassBuilder(@NotNull Project project, @NotNull String simpleName, @NotNull String qualifiedName) {
-    super(JavaPsiFacade.getElementFactory(project).createClass(simpleName));
-    myModifierList = new LombokLightModifierList(getManager(), JavaLanguage.INSTANCE);
-    myBaseIcon = LombokIcons.CLASS_ICON;
-    setQualifiedName(qualifiedName);
-  }
-
-  @Nullable
-  @Override
-  public String getQualifiedName() {
-    return myQualifiedName;
-  }
-
-  public void setQualifiedName(@NotNull String qualifiedName) {
+  public LombokLightClassBuilder(@NotNull PsiElement context, @NotNull String simpleName, @NotNull String qualifiedName) {
+    super(context, simpleName);
     myQualifiedName = qualifiedName;
-  }
-
-  @NotNull
-  @Override
-  public PsiMethod[] getConstructors() {
-    return myConstructors;
-  }
-
-  public void setConstructors(@NotNull PsiMethod[] constructors) {
-    myConstructors = constructors;
+    myBaseIcon = LombokIcons.CLASS_ICON;
   }
 
   @Override
   @NotNull
   public PsiField[] getFields() {
-    return myFields;
+    return myFields.toArray(new PsiField[myFields.size()]);
   }
 
-  public void setFields(@NotNull PsiField[] fields) {
-    myFields = fields;
-  }
-
-  @NotNull
-  @Override
-  public PsiMethod[] getMethods() {
-    // http://stackoverflow.com/a/784842/411905
-    PsiMethod[] result = Arrays.copyOf(myMethods, myMethods.length + myConstructors.length);
-    System.arraycopy(myConstructors, 0, result, myMethods.length, myConstructors.length);
-    return result;
-  }
-
-  public void setMethods(@NotNull PsiMethod[] methods) {
-    myMethods = methods;
-  }
-
-  @NotNull
-  @Override
-  public LombokLightModifierList getModifierList() {
-    return myModifierList;
-  }
-
-  @Override
-  public boolean hasModifierProperty(@NonNls @NotNull String name) {
-    return myModifierList.hasModifierProperty(name);
-  }
-
-  @Nullable
-  @Override
-  public PsiTypeParameterList getTypeParameterList() {
-    return myTypeParameterList;
-  }
-
-  @NotNull
-  @Override
-  public PsiTypeParameter[] getTypeParameters() {
-    return myTypeParameters;
-  }
-
-  public void setTypeParameterList(@Nullable PsiTypeParameterList list) {
-    myTypeParameterList = list;
-    if (null == myTypeParameterList) {
-      myTypeParameters = PsiTypeParameter.EMPTY_ARRAY;
-    } else {
-      myTypeParameters = myTypeParameterList.getTypeParameters();
+  public LightPsiClassBuilder addField(PsiField field) {
+    if (field instanceof LightFieldBuilder) {
+      ((LightFieldBuilder) field).setContainingClass(this);
     }
-  }
-
-  @Nullable
-  @Override
-  public PsiClass getContainingClass() {
-    return myContainingClass;
-  }
-
-  public void setContainingClass(@Nullable PsiClass containingClass) {
-    myContainingClass = containingClass;
+    myFields.add(field);
+    return this;
   }
 
   @Override
   public PsiElement getScope() {
-    if (myContainingClass != null) {
-      return myContainingClass.getScope();
+    if (getContainingClass() != null) {
+      return getContainingClass().getScope();
     }
     return super.getScope();
   }
 
   @Override
   public PsiElement getParent() {
-    if (myContainingClass != null) {
-      return myContainingClass.getParent();
-    }
-    return super.getParent();
+    return getContainingClass();
+  }
+
+  @Nullable
+  @Override
+  public String getQualifiedName() {
+    return myQualifiedName;
   }
 
   @Override
@@ -149,6 +73,52 @@ public class LombokLightClassBuilder extends LightClass {
   public TextRange getTextRange() {
     TextRange r = super.getTextRange();
     return r == null ? TextRange.EMPTY_RANGE : r;
+  }
+
+  @Override
+  public PsiFile getContainingFile() {
+    if (null != getContainingClass()) {
+      return getContainingClass().getContainingFile();
+    }
+    return super.getContainingFile();
+  }
+
+  public LombokLightClassBuilder withModifier(@PsiModifier.ModifierConstant @NotNull @NonNls String modifier) {
+    getModifierList().addModifier(modifier);
+    return this;
+  }
+
+  public LombokLightClassBuilder withContainingClass(@NotNull PsiClass containingClass) {
+    setContainingClass(containingClass);
+    return this;
+  }
+
+  public LombokLightClassBuilder withNavigationElement(PsiElement navigationElement) {
+    setNavigationElement(navigationElement);
+    return this;
+  }
+
+  public LombokLightClassBuilder withFields(@NotNull Collection<PsiField> fields) {
+    for (PsiField field : fields) {
+      addField(field);
+    }
+    return this;
+  }
+
+  public LombokLightClassBuilder withMethods(@NotNull Collection<PsiMethod> methods) {
+    for (PsiMethod method : methods) {
+      addMethod(method);
+    }
+    return this;
+  }
+
+  public LombokLightClassBuilder withParameterTypes(@Nullable PsiTypeParameterList parameterList) {
+    if (parameterList != null) {
+      for (PsiTypeParameter typeParameter : parameterList.getTypeParameters()) {
+        getTypeParameterList().addParameter(typeParameter);
+      }
+    }
+    return this;
   }
 
   @Override
@@ -169,40 +139,5 @@ public class LombokLightClassBuilder extends LightClass {
   @Override
   public int hashCode() {
     return myQualifiedName.hashCode();
-  }
-
-  public LombokLightClassBuilder withModifier(@PsiModifier.ModifierConstant @NotNull @NonNls String modifier) {
-    getModifierList().addModifier(modifier);
-    return this;
-  }
-
-  public LombokLightClassBuilder withContainingClass(@NotNull PsiClass containingClass) {
-    setContainingClass(containingClass);
-    return this;
-  }
-
-  public LombokLightClassBuilder withFields(@NotNull Collection<PsiField> fields) {
-    setFields(fields.toArray(new PsiField[fields.size()]));
-    return this;
-  }
-
-  public LombokLightClassBuilder withMethods(@NotNull Collection<PsiMethod> methods) {
-    setMethods(methods.toArray(new PsiMethod[methods.size()]));
-    return this;
-  }
-
-  public LombokLightClassBuilder withConstructors(@NotNull Collection<PsiMethod> constructors) {
-    setConstructors(constructors.toArray(new PsiMethod[constructors.size()]));
-    return this;
-  }
-
-  public LombokLightClassBuilder withParameterTypes(@Nullable PsiTypeParameterList parameterList) {
-    setTypeParameterList(parameterList);
-    return this;
-  }
-
-  public LombokLightClassBuilder withNavigationElement(PsiElement navigationElement) {
-    setNavigationElement(navigationElement);
-    return this;
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -262,6 +262,7 @@
 		<ul>
 		<li>0.15
 				<ol>
+            <li>Fixed #145: Overriding builder() method for @Builder shows false compilation error</li>
             <li>Fixed #162: @Data/@XConstructor bug with default constructor</li>
             <li>Improved #260: Handling val - Inferred Type is Object</li>
             <li>Fixed #290: Getter and FieldDefaults with parameter AccessLevel in Enum shows "cannot access"</li>

--- a/test-manual/src/main/java/de/plushnikov/builder/issue145/MyBuilder.java
+++ b/test-manual/src/main/java/de/plushnikov/builder/issue145/MyBuilder.java
@@ -1,0 +1,15 @@
+package de.plushnikov.builder.issue145;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MyBuilder {
+
+    private String myString;
+
+    public static MyBuilderBuilder builder() {
+        return new MyBuilderBuilder().myString("my  default value");
+    }
+}

--- a/test-manual/src/main/java/de/plushnikov/builder/issue303/KeywordDefinition.java
+++ b/test-manual/src/main/java/de/plushnikov/builder/issue303/KeywordDefinition.java
@@ -1,0 +1,14 @@
+package de.plushnikov.builder.issue303;
+
+import lombok.Builder;
+
+@Builder
+public class KeywordDefinition {
+  private String one;
+  private int two;
+
+  public static class KeywordDefinitionBuilder2 extends KeywordDefinitionBuilder {
+    private float someFloat;
+  }
+
+}

--- a/test-manual/src/main/java/de/plushnikov/builder/issue303/KeywordDefinitionBuilder2.java
+++ b/test-manual/src/main/java/de/plushnikov/builder/issue303/KeywordDefinitionBuilder2.java
@@ -1,0 +1,6 @@
+package de.plushnikov.builder.issue303;
+
+public class KeywordDefinitionBuilder2 extends KeywordDefinition.KeywordDefinitionBuilder {
+
+}
+

--- a/testData/action/delombok/builder/afterBuilderAtConstructorSimple.java
+++ b/testData/action/delombok/builder/afterBuilderAtConstructorSimple.java
@@ -23,12 +23,12 @@ public class BuilderAtConstructorSimple {
     BuilderAtConstructorSimpleBuilder() {
     }
 
-    public BuilderAtConstructorSimple.BuilderAtConstructorSimpleBuilder myInt(int myInt) {
+    public BuilderAtConstructorSimpleBuilder myInt(int myInt) {
       this.myInt = myInt;
       return this;
     }
 
-    public BuilderAtConstructorSimple.BuilderAtConstructorSimpleBuilder myString(String myString) {
+    public BuilderAtConstructorSimpleBuilder myString(String myString) {
       this.myString = myString;
       return this;
     }

--- a/testData/action/delombok/builder/afterBuilderAtConstructorSimplePredefined.java
+++ b/testData/action/delombok/builder/afterBuilderAtConstructorSimplePredefined.java
@@ -18,7 +18,7 @@ public class BuilderAtConstructorSimplePredefined {
     BuilderAtConstructorSimplePredefinedBuilder() {
     }
 
-    public BuilderAtConstructorSimplePredefined.BuilderAtConstructorSimplePredefinedBuilder myString(String myString) {
+    public BuilderAtConstructorSimplePredefinedBuilder myString(String myString) {
       this.myString = myString + "something";
       return this;
     }

--- a/testData/action/delombok/builder/afterBuilderAtMethodSimple.java
+++ b/testData/action/delombok/builder/afterBuilderAtMethodSimple.java
@@ -25,12 +25,12 @@ public class BuilderAtMethodSimple {
     BuilderAtMethodSimpleBuilder() {
     }
 
-    public BuilderAtMethodSimple.BuilderAtMethodSimpleBuilder myInt(int myInt) {
+    public BuilderAtMethodSimpleBuilder myInt(int myInt) {
       this.myInt = myInt;
       return this;
     }
 
-    public BuilderAtMethodSimple.BuilderAtMethodSimpleBuilder myString(String myString) {
+    public BuilderAtMethodSimpleBuilder myString(String myString) {
       this.myString = myString;
       return this;
     }

--- a/testData/action/delombok/builder/afterBuilderAtMethodSimplePredefined.java
+++ b/testData/action/delombok/builder/afterBuilderAtMethodSimplePredefined.java
@@ -20,7 +20,7 @@ public class BuilderAtMethodSimplePredefined {
     BuilderAtMethodSimplePredefinedBuilder() {
     }
 
-    public BuilderAtMethodSimplePredefined.BuilderAtMethodSimplePredefinedBuilder myString(String myString) {
+    public BuilderAtMethodSimplePredefinedBuilder myString(String myString) {
       this.myString = myString + "something";
       return this;
     }

--- a/testData/action/delombok/builder/afterBuilderSimple.java
+++ b/testData/action/delombok/builder/afterBuilderSimple.java
@@ -24,12 +24,12 @@ public class BuilderSimple {
     BuilderSimpleBuilder() {
     }
 
-    public BuilderSimple.BuilderSimpleBuilder myInt(int myInt) {
+    public BuilderSimpleBuilder myInt(int myInt) {
       this.myInt = myInt;
       return this;
     }
 
-    public BuilderSimple.BuilderSimpleBuilder myString(String myString) {
+    public BuilderSimpleBuilder myString(String myString) {
       this.myString = myString;
       return this;
     }

--- a/testData/action/delombok/builder/afterBuilderSimplePredefined.java
+++ b/testData/action/delombok/builder/afterBuilderSimplePredefined.java
@@ -19,7 +19,7 @@ public class BuilderSimplePreDefined {
     BuilderSimplePreDefinedBuilder() {
     }
 
-    public BuilderSimplePreDefined.BuilderSimplePreDefinedBuilder myString(String myString) {
+    public BuilderSimplePreDefinedBuilder myString(String myString) {
       this.myString = myString + "something";
       return this;
     }

--- a/testData/action/delombok/builder/afterBuilderSingularMap.java
+++ b/testData/action/delombok/builder/afterBuilderSingularMap.java
@@ -21,7 +21,7 @@ public class BuilderSingularMap {
     BuilderSingularMapBuilder() {
     }
 
-    public BuilderSingularMap.BuilderSingularMapBuilder myMap(String myMapKey, String myMapValue) {
+    public BuilderSingularMapBuilder myMap(String myMapKey, String myMapValue) {
       if (this.myMap$key == null) {
         this.myMap$key = new ArrayList<String>();
         this.myMap$value = new ArrayList<String>();
@@ -31,7 +31,7 @@ public class BuilderSingularMap {
       return this;
     }
 
-    public BuilderSingularMap.BuilderSingularMapBuilder myMap(Map<? extends String, ? extends String> myMap) {
+    public BuilderSingularMapBuilder myMap(Map<? extends String, ? extends String> myMap) {
       if (this.myMap$key == null) {
         this.myMap$key = new ArrayList<String>();
         this.myMap$value = new ArrayList<String>();
@@ -43,7 +43,7 @@ public class BuilderSingularMap {
       return this;
     }
 
-    public BuilderSingularMap.BuilderSingularMapBuilder clearMyMap() {
+    public BuilderSingularMapBuilder clearMyMap() {
       if (this.myMap$key != null) {
         this.myMap$key.clear();
         this.myMap$value.clear();

--- a/testData/action/delombok/builder/beforeBuilderAtConstructorSimplePredefined.java
+++ b/testData/action/delombok/builder/beforeBuilderAtConstructorSimplePredefined.java
@@ -11,7 +11,7 @@ public class BuilderAtConstructorSimplePredefined {
   static class BuilderAtConstructorSimplePredefinedBuilder {
     private int myInt;
 
-    public BuilderAtConstructorSimplePredefined.BuilderAtConstructorSimplePredefinedBuilder myString(String myString) {
+    public BuilderAtConstructorSimplePredefinedBuilder myString(String myString) {
       this.myString = myString + "something";
       return this;
     }

--- a/testData/action/delombok/builder/beforeBuilderAtMethodSimplePredefined.java
+++ b/testData/action/delombok/builder/beforeBuilderAtMethodSimplePredefined.java
@@ -13,7 +13,7 @@ public class BuilderAtMethodSimplePredefined {
   static class BuilderAtMethodSimplePredefinedBuilder {
     private int myInt;
 
-    public BuilderAtMethodSimplePredefined.BuilderAtMethodSimplePredefinedBuilder myString(String myString) {
+    public BuilderAtMethodSimplePredefinedBuilder myString(String myString) {
       this.myString = myString + "something";
       return this;
     }

--- a/testData/action/delombok/builder/beforeBuilderSimplePredefined.java
+++ b/testData/action/delombok/builder/beforeBuilderSimplePredefined.java
@@ -6,7 +6,7 @@ public class BuilderSimplePreDefined {
   static class BuilderSimplePreDefinedBuilder {
     private int myInt;
 
-    public BuilderSimplePreDefined.BuilderSimplePreDefinedBuilder myString(String myString) {
+    public BuilderSimplePreDefinedBuilder myString(String myString) {
       this.myString = myString + "something";
       return this;
     }

--- a/testData/after/builder/BuilderInstanceMethod.java
+++ b/testData/after/builder/BuilderInstanceMethod.java
@@ -74,6 +74,6 @@ class BuilderInstanceMethod<T> {
 	@java.lang.SuppressWarnings("all")
 	@javax.annotation.Generated("lombok")
 	public StringBuilder builder() {
-		return new StringBuilder();
+		return new BuilderInstanceMethod.StringBuilder();
 	}
 }


### PR DESCRIPTION
This looks like a fix for #145 
The new implementation of LombokLightClassBuilder provide correct package for generated BuilderClass (the same as the containing class). Previous Implementation provided default package for all generated classes. I think this was a root of the problem in #145.
@AlexejK can you have a look and maybe do more manually tests in your environment?