### PR TITLE
Add support for default values in builder.

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/processor/handler/BuilderHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/handler/BuilderHandler.java
@@ -701,7 +701,11 @@ public class BuilderHandler {
   }
 
   private boolean isBuilderDefaultAnnotated(@NotNull PsiField psiField) {
-    for(PsiAnnotation psiAnnotation: psiField.getAnnotations()) {
+    if (psiField.getModifierList() == null) {
+      return false;
+    }
+    PsiAnnotation[] annotations = psiField.getModifierList().getAnnotations();
+    for(PsiAnnotation psiAnnotation: annotations) {
       if (psiAnnotation.getQualifiedName() != null &&
         psiAnnotation.getQualifiedName().equals(Builder.Default.class.getCanonicalName())) {
         return true;

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/handler/BuilderHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/handler/BuilderHandler.java
@@ -553,8 +553,9 @@ public class BuilderHandler {
       if (null != modifierList) {
         //Skip static fields.
         selectField = !modifierList.hasModifierProperty(PsiModifier.STATIC);
-        // skip initialized final fields
-        selectField &= !(null != psiField.getInitializer() && modifierList.hasModifierProperty(PsiModifier.FINAL));
+        // skip initialized final fields unless annotated with @Builder.Default
+        selectField &= !(null != psiField.getInitializer() && modifierList.hasModifierProperty(PsiModifier.FINAL))
+          || isBuilderDefaultAnnotated(psiField);
       }
       //Skip fields that start with $
       final String psiFieldName = psiField.getName();
@@ -697,6 +698,16 @@ public class BuilderHandler {
     for (PsiTypeParameter psiTypeParameter : psiTypeParameters) {
       methodBuilder.withTypeParameter(psiTypeParameter);
     }
+  }
+
+  private boolean isBuilderDefaultAnnotated(@NotNull PsiField psiField) {
+    for(PsiAnnotation psiAnnotation: psiField.getAnnotations()) {
+      if (psiAnnotation.getQualifiedName() != null &&
+        psiAnnotation.getQualifiedName().equals(Builder.Default.class.getCanonicalName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   // These exist just to support the 'old' lombok.experimental.Builder, which had these properties. lombok.Builder no longer has them.

--- a/src/test/java/de/plushnikov/intellij/plugin/inspection/BuilderInspectionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/inspection/BuilderInspectionTest.java
@@ -34,4 +34,8 @@ public class BuilderInspectionTest extends LombokInspectionTest {
     //TODO implement test after adding support for Builder.Default
     doTest();
   }
+
+  public void testBuilderDefaultValue() throws Exception {
+    doTest();
+  }
 }

--- a/src/test/java/de/plushnikov/intellij/plugin/inspection/BuilderInspectionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/inspection/BuilderInspectionTest.java
@@ -31,7 +31,6 @@ public class BuilderInspectionTest extends LombokInspectionTest {
   }
 
   public void testBuilderDefaultsWarnings() throws Exception {
-    //TODO implement test after adding support for Builder.Default
     doTest();
   }
 

--- a/testData/inspection/builder/BuilderDefaultValue.java
+++ b/testData/inspection/builder/BuilderDefaultValue.java
@@ -1,0 +1,20 @@
+import lombok.Builder;
+import lombok.Value;
+
+@Builder
+@Value
+public class BuilderDefaultValue
+{
+  @Builder.Default
+  int canSet = 0;
+  int canNotSet = 0;
+
+  public static void testMe()
+  {
+    BuilderDefaultValue.builder()
+      .canSet(1);
+
+    BuilderDefaultValue.builder()
+      .<error descr="Cannot resolve method 'canNotSet(int)'">canNotSet</error>(1);
+  }
+}


### PR DESCRIPTION
Fixes #375

Combining @Value and @Builder with default values was not interpreted correctly by the plugin. This commit
allows setting default values in builder which can still be overridden.