### PR TITLE
Bump IntelliJ version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,8 @@
 #ideaVersion=2017.2
 #ideaVersion=2017.2.6
 #ideaVersion=2017.3
-ideaVersion=2017.3.4
+#ideaVersion=2017.3.4
+ideaVersion=2018.1
 #ideaVersion = LATEST-EAP-SNAPSHOT
 #ideaVersion = LATEST-TRUNK-SNAPSHOT
 #


### PR DESCRIPTION
Bumped the IntelliJ version, built and tested it, installed it in IntelliJ 2018.1 and opened a project in which it is used. Seems to work.