### PR TITLE
Fix the all args constructor when using defaults.

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/WitherProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/WitherProcessor.java
@@ -15,6 +15,7 @@ import de.plushnikov.intellij.plugin.thirdparty.LombokUtils;
 import de.plushnikov.intellij.plugin.util.LombokProcessorUtil;
 import de.plushnikov.intellij.plugin.util.PsiAnnotationSearchUtil;
 import de.plushnikov.intellij.plugin.util.PsiClassUtil;
+import lombok.Builder;
 import lombok.experimental.Wither;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,6 +24,8 @@ import java.util.Collection;
 import java.util.List;
 
 public class WitherProcessor extends AbstractClassProcessor {
+  private static final String BUILDER_DEFAULT_ANNOTATION = Builder.Default.class.getName().replace("$", ".");
+
   private final WitherFieldProcessor fieldProcessor;
 
   public WitherProcessor(WitherFieldProcessor fieldProcessor) {
@@ -83,8 +86,9 @@ public class WitherProcessor extends AbstractClassProcessor {
       if (null != modifierList) {
         // Skip static fields.
         createWither = !modifierList.hasModifierProperty(PsiModifier.STATIC);
-        // Skip final fields
-        createWither &= !(modifierList.hasModifierProperty(PsiModifier.FINAL) && psiField.hasInitializer());
+        // Skip final fields that are initialized and not annotated with @Builder.Default
+        createWither &= !(modifierList.hasModifierProperty(PsiModifier.FINAL) && psiField.hasInitializer() &&
+          PsiAnnotationSearchUtil.findAnnotation(psiField, BUILDER_DEFAULT_ANNOTATION) == null);
         // Skip fields that start with $
         createWither &= !psiField.getName().startsWith(LombokUtils.LOMBOK_INTERN_FIELD_MARKER);
         // Skip fields having Wither annotation already

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/constructor/AbstractConstructorClassProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/constructor/AbstractConstructorClassProcessor.java
@@ -33,6 +33,7 @@ import de.plushnikov.intellij.plugin.util.PsiAnnotationUtil;
 import de.plushnikov.intellij.plugin.util.PsiClassUtil;
 import de.plushnikov.intellij.plugin.util.PsiElementUtil;
 import de.plushnikov.intellij.plugin.util.PsiMethodUtil;
+import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 import org.jetbrains.annotations.NotNull;
@@ -51,6 +52,7 @@ import java.util.List;
  * @author Plushnikov Michail
  */
 public abstract class AbstractConstructorClassProcessor extends AbstractClassProcessor {
+  private static final String BUILDER_DEFAULT_ANNOTATION = Builder.Default.class.getName().replace("$", ".");
 
   AbstractConstructorClassProcessor(@NotNull Class<? extends Annotation> supportedAnnotationClass, @NotNull Class<? extends PsiElement> supportedClass) {
     super(supportedClass, supportedAnnotationClass);
@@ -183,7 +185,8 @@ public abstract class AbstractConstructorClassProcessor extends AbstractClassPro
 
         boolean isFinal = isFieldFinal(psiField, modifierList, classAnnotatedWithValue);
         // skip initialized final fields
-        addField &= (!isFinal || null == psiField.getInitializer());
+        addField &= (!isFinal || null == psiField.getInitializer() ||
+          PsiAnnotationSearchUtil.findAnnotation(psiField, BUILDER_DEFAULT_ANNOTATION) != null);
       }
 
       if (addField) {

--- a/testData/inspection/builder/BuilderDefaultValue.java
+++ b/testData/inspection/builder/BuilderDefaultValue.java
@@ -1,8 +1,10 @@
 import lombok.Builder;
 import lombok.Value;
+import lombok.experimental.Wither;
 
 @Builder
 @Value
+@Wither
 public class BuilderDefaultValue
 {
   @lombok.Builder.Default
@@ -20,5 +22,12 @@ public class BuilderDefaultValue
       .<error descr="Cannot resolve method 'canNotSet(int)'">canNotSet</error>(1);
 
     new BuilderDefaultValue(1,1);
+
+    BuilderDefaultValue bdv = BuilderDefaultValue.builder()
+      .mustSet(1)
+      .canSet(1)
+      .build();
+
+    bdv.withCanSet(2).withMustSet(2);
   }
 }

--- a/testData/inspection/builder/BuilderDefaultValue.java
+++ b/testData/inspection/builder/BuilderDefaultValue.java
@@ -8,13 +8,17 @@ public class BuilderDefaultValue
   @lombok.Builder.Default
   int canSet = 0;
   int canNotSet = 0;
+  int mustSet;
 
   public static void testMe()
   {
     BuilderDefaultValue.builder()
+      .mustSet(1)
       .canSet(1);
 
     BuilderDefaultValue.builder()
       .<error descr="Cannot resolve method 'canNotSet(int)'">canNotSet</error>(1);
+
+    new BuilderDefaultValue(1,1);
   }
 }


### PR DESCRIPTION
Lombok generates an all args constructor with all fields, including ones with defaults.
The plugin generated a constructor with only normal fields. This resulted in apparent
compile errors