### PR TITLE
Updated gradle.properties to support 2018.2 IntelliJ

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,8 @@
 #ideaVersion=2017.3
 #ideaVersion=2017.3.5
 #ideaVersion=2018.1
-ideaVersion=2018.1.6
+#ideaVersion=2018.1.6
+ideaVersion=2018.2
 #ideaVersion=LATEST-EAP-SNAPSHOT
 #ideaVersion = LATEST-TRUNK-SNAPSHOT
 #


### PR DESCRIPTION
I don't know if it's gonna work with the IntelliJ version but 
just opening the PR up so that maintainers can look at it and 
decide to merge it if this is the only change needed.