### PR TITLE
fixed #553: grammar in message (possible outdated)

### DIFF
--- a/src/main/resources/messages/lombokBundle.properties
+++ b/src/main/resources/messages/lombokBundle.properties
@@ -12,7 +12,7 @@ config.warn.annotation-processing.disabled.message=<br>\
   For the plugin to function correctly, please enable it under<br>\
   <a href="#">"Settings > Build > Compiler > Annotation Processors"</a><br>
 
-config.warn.dependency.outdated.title=Lombok Dependency is possible outdated
+config.warn.dependency.outdated.title=Lombok Dependency is possibly outdated
 config.warn.dependency.outdated.message=<br>\
   Project "{0}" and Module "{1}" seem to have outdated lombok dependency added.<br>\
   Configured version "{2}", but there is at least version "{3}" already released<br>\


### PR DESCRIPTION
Corrected the grammar in the warning about the outdated lombok dependency.