### PR TITLE
@FieldNameConstants implement merging of existing inner class and fie…

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/action/delombok/DelombokEverythingAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/action/delombok/DelombokEverythingAction.java
@@ -2,7 +2,8 @@ package de.plushnikov.intellij.plugin.action.delombok;
 
 import de.plushnikov.intellij.plugin.processor.clazz.DataProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.EqualsAndHashCodeProcessor;
-import de.plushnikov.intellij.plugin.processor.clazz.FieldNameConstantsProcessor;
+import de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNameConstantsPredefinedInnerClassFieldProcessor;
+import de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNameConstantsProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.GetterProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.SetterProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.ToStringProcessor;
@@ -60,6 +61,7 @@ public class DelombokEverythingAction extends AbstractDelombokAction {
       findExtension(DelegateMethodProcessor.class),
 
       findExtension(FieldNameConstantsProcessor.class),
+      findExtension(FieldNameConstantsPredefinedInnerClassFieldProcessor.class),
 
       findExtension(BuilderPreDefinedInnerClassFieldProcessor.class),
       findExtension(BuilderPreDefinedInnerClassMethodProcessor.class),

--- a/src/main/java/de/plushnikov/intellij/plugin/action/delombok/DelombokFieldNameConstantsAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/action/delombok/DelombokFieldNameConstantsAction.java
@@ -1,6 +1,7 @@
 package de.plushnikov.intellij.plugin.action.delombok;
 
-import de.plushnikov.intellij.plugin.processor.clazz.FieldNameConstantsProcessor;
+import de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNameConstantsPredefinedInnerClassFieldProcessor;
+import de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNameConstantsProcessor;
 import org.jetbrains.annotations.NotNull;
 
 import static de.plushnikov.intellij.plugin.util.ExtensionsUtil.findExtension;
@@ -8,7 +9,8 @@ import static de.plushnikov.intellij.plugin.util.ExtensionsUtil.findExtension;
 public class DelombokFieldNameConstantsAction extends AbstractDelombokAction {
   @NotNull
   protected DelombokHandler createHandler() {
-    return new DelombokHandler(
-      findExtension(FieldNameConstantsProcessor.class));
+    return new DelombokHandler(true,
+      findExtension(FieldNameConstantsProcessor.class),
+      findExtension(FieldNameConstantsPredefinedInnerClassFieldProcessor.class));
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/fieldnameconstants/AbstractFieldNameConstantsProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/fieldnameconstants/AbstractFieldNameConstantsProcessor.java
@@ -1,4 +1,4 @@
-package de.plushnikov.intellij.plugin.processor.clazz;
+package de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants;
 
 import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiClass;
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiModifierList;
 import de.plushnikov.intellij.plugin.lombokconfig.ConfigDiscovery;
 import de.plushnikov.intellij.plugin.problem.ProblemBuilder;
 import de.plushnikov.intellij.plugin.processor.LombokPsiElementUsage;
-import de.plushnikov.intellij.plugin.processor.handler.FieldNameConstantsHandler;
+import de.plushnikov.intellij.plugin.processor.clazz.AbstractClassProcessor;
 import de.plushnikov.intellij.plugin.thirdparty.LombokUtils;
 import de.plushnikov.intellij.plugin.util.LombokProcessorUtil;
 import de.plushnikov.intellij.plugin.util.PsiAnnotationSearchUtil;
@@ -18,23 +18,17 @@ import de.plushnikov.intellij.plugin.util.PsiClassUtil;
 import lombok.experimental.FieldNameConstants;
 import org.jetbrains.annotations.NotNull;
 
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
-/**
- * Inspect and validate @FieldNameConstants lombok annotation on a field
- * Creates Inner class containing string constants of the field name for each field of this class
- *
- * @author Plushnikov Michail
- */
-public class FieldNameConstantsProcessor extends AbstractClassProcessor {
+public abstract class AbstractFieldNameConstantsProcessor extends AbstractClassProcessor {
 
   private static final String FIELD_NAME_CONSTANTS_INCLUDE = FieldNameConstants.Include.class.getName().replace("$", ".");
   private static final String FIELD_NAME_CONSTANTS_EXCLUDE = FieldNameConstants.Exclude.class.getName().replace("$", ".");
 
-  public FieldNameConstantsProcessor(@NotNull ConfigDiscovery configDiscovery) {
-    super(configDiscovery, PsiClass.class, FieldNameConstants.class);
+  protected AbstractFieldNameConstantsProcessor(@NotNull ConfigDiscovery configDiscovery, @NotNull Class<? extends PsiElement> supportedClass, @NotNull Class<? extends Annotation> supportedAnnotationClass) {
+    super(configDiscovery, supportedClass, supportedAnnotationClass);
   }
 
   @Override
@@ -50,18 +44,8 @@ public class FieldNameConstantsProcessor extends AbstractClassProcessor {
     return true;
   }
 
-  protected void generatePsiElements(@NotNull PsiClass psiClass, @NotNull PsiAnnotation psiAnnotation, @NotNull List<? super PsiElement> target) {
-    final Collection<PsiField> psiFields = filterFields(psiClass, psiAnnotation);
-    if (!psiFields.isEmpty()) {
-      PsiClass innerClassOrEnum = FieldNameConstantsHandler.createInnerClassOrEnum(psiClass, psiAnnotation, psiFields);
-      if (innerClassOrEnum != null) {
-        target.add(innerClassOrEnum);
-      }
-    }
-  }
-
   @NotNull
-  private Collection<PsiField> filterFields(@NotNull PsiClass psiClass, PsiAnnotation psiAnnotation) {
+  Collection<PsiField> filterFields(@NotNull PsiClass psiClass, PsiAnnotation psiAnnotation) {
     final Collection<PsiField> psiFields = new ArrayList<>();
 
     final boolean onlyExplicitlyIncluded = PsiAnnotationUtil.getBooleanAnnotationValue(psiAnnotation, "onlyExplicitlyIncluded", false);

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/fieldnameconstants/FieldNameConstantsPredefinedInnerClassFieldProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/fieldnameconstants/FieldNameConstantsPredefinedInnerClassFieldProcessor.java
@@ -1,0 +1,92 @@
+package de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants;
+
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiModifierList;
+import de.plushnikov.intellij.plugin.lombokconfig.ConfigDiscovery;
+import de.plushnikov.intellij.plugin.problem.ProblemBuilder;
+import de.plushnikov.intellij.plugin.problem.ProblemEmptyBuilder;
+import de.plushnikov.intellij.plugin.processor.LombokPsiElementUsage;
+import de.plushnikov.intellij.plugin.processor.clazz.AbstractClassProcessor;
+import de.plushnikov.intellij.plugin.processor.handler.FieldNameConstantsHandler;
+import de.plushnikov.intellij.plugin.psi.LombokLightClassBuilder;
+import de.plushnikov.intellij.plugin.thirdparty.LombokUtils;
+import de.plushnikov.intellij.plugin.util.LombokProcessorUtil;
+import de.plushnikov.intellij.plugin.util.PsiAnnotationSearchUtil;
+import de.plushnikov.intellij.plugin.util.PsiAnnotationUtil;
+import de.plushnikov.intellij.plugin.util.PsiClassUtil;
+import lombok.experimental.FieldNameConstants;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Inspect and validate @FieldNameConstants lombok annotation on a field
+ * Creates Inner class containing string constants of the field name for each field of this class
+ *
+ * @author Plushnikov Michail
+ */
+public class FieldNameConstantsPredefinedInnerClassFieldProcessor extends AbstractFieldNameConstantsProcessor {
+
+  public FieldNameConstantsPredefinedInnerClassFieldProcessor(@NotNull ConfigDiscovery configDiscovery) {
+    super(configDiscovery, PsiField.class, FieldNameConstants.class);
+  }
+
+  @NotNull
+  @Override
+  public List<? super PsiElement> process(@NotNull PsiClass psiClass) {
+    if (psiClass.getParent() instanceof PsiClass) {
+      PsiClass parentClass = (PsiClass) psiClass.getParent();
+      PsiAnnotation psiAnnotation = PsiAnnotationSearchUtil.findAnnotation(parentClass, getSupportedAnnotationClasses());
+      if (null != psiAnnotation) {
+        ProblemEmptyBuilder problemBuilder = ProblemEmptyBuilder.getInstance();
+        if (super.validate(psiAnnotation, parentClass, problemBuilder)) {
+          final String typeName = FieldNameConstantsHandler.getTypeName(parentClass, psiAnnotation);
+          if (typeName.equals(psiClass.getName())) {
+            if (validate(psiAnnotation, parentClass, problemBuilder)) {
+              List<? super PsiElement> result = new ArrayList<>();
+              generatePsiElements(parentClass, psiClass, psiAnnotation, result);
+              return result;
+            }
+          }
+        }
+      }
+    }
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected boolean validate(@NotNull PsiAnnotation psiAnnotation, @NotNull PsiClass psiClass, @NotNull ProblemBuilder builder) {
+    final String typeName = FieldNameConstantsHandler.getTypeName(psiClass, psiAnnotation);
+    Optional<PsiClass> innerClass = PsiClassUtil.getInnerClassInternByName(psiClass, typeName);
+    if (innerClass.isPresent()) {
+      final boolean asEnum = PsiAnnotationUtil.getBooleanAnnotationValue(psiAnnotation, "asEnum", false);
+      if (innerClass.get().isEnum() != asEnum) {
+        builder.addError("@FieldNameConstants inner type already exists, but asEnum=" + asEnum + " does not match existing type");
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  protected void generatePsiElements(@NotNull PsiClass psiClass, @NotNull PsiAnnotation psiAnnotation, @NotNull List<? super PsiElement> target) {
+    //do nothing
+  }
+
+
+  private void generatePsiElements(@NotNull PsiClass psiClass, @NotNull PsiClass existingInnerClass, @NotNull PsiAnnotation psiAnnotation, @NotNull List<? super PsiElement> target) {
+    final Collection<PsiField> psiFields = filterFields(psiClass, psiAnnotation);
+    if (!psiFields.isEmpty()) {
+      List<PsiField> newFields = FieldNameConstantsHandler.createFields(existingInnerClass, psiFields);
+      target.addAll(newFields);
+    }
+  }
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/fieldnameconstants/FieldNameConstantsProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/fieldnameconstants/FieldNameConstantsProcessor.java
@@ -1,0 +1,44 @@
+package de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants;
+
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiField;
+import de.plushnikov.intellij.plugin.lombokconfig.ConfigDiscovery;
+import de.plushnikov.intellij.plugin.processor.handler.FieldNameConstantsHandler;
+import de.plushnikov.intellij.plugin.psi.LombokLightClassBuilder;
+import de.plushnikov.intellij.plugin.util.PsiClassUtil;
+import lombok.experimental.FieldNameConstants;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Inspect and validate @FieldNameConstants lombok annotation on a field
+ * Creates Inner class containing string constants of the field name for each field of this class
+ *
+ * @author Plushnikov Michail
+ */
+public class FieldNameConstantsProcessor extends AbstractFieldNameConstantsProcessor {
+
+  public FieldNameConstantsProcessor(@NotNull ConfigDiscovery configDiscovery) {
+    super(configDiscovery, PsiClass.class, FieldNameConstants.class);
+  }
+
+  protected void generatePsiElements(@NotNull PsiClass psiClass, @NotNull PsiAnnotation psiAnnotation, @NotNull List<? super PsiElement> target) {
+    final Collection<PsiField> psiFields = filterFields(psiClass, psiAnnotation);
+    if (!psiFields.isEmpty()) {
+      final String typeName = FieldNameConstantsHandler.getTypeName(psiClass, psiAnnotation);
+      Optional<PsiClass> existingClass = PsiClassUtil.getInnerClassInternByName(psiClass, typeName);
+      if (!existingClass.isPresent()) {
+        LombokLightClassBuilder innerClassOrEnum = FieldNameConstantsHandler.createInnerClassOrEnum(typeName, psiClass, psiAnnotation);
+        if (innerClassOrEnum != null) {
+          FieldNameConstantsHandler.createFields(innerClassOrEnum, psiFields).forEach(innerClassOrEnum::withField);
+          target.add(innerClassOrEnum);
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/handler/FieldNameConstantsHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/handler/FieldNameConstantsHandler.java
@@ -1,6 +1,16 @@
 package de.plushnikov.intellij.plugin.processor.handler;
 
-import com.intellij.psi.*;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiClassType;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementFactory;
+import com.intellij.psi.PsiExpression;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiType;
 import com.intellij.psi.search.GlobalSearchScope;
 import de.plushnikov.intellij.plugin.lombokconfig.ConfigDiscovery;
 import de.plushnikov.intellij.plugin.lombokconfig.ConfigKey;
@@ -9,34 +19,55 @@ import de.plushnikov.intellij.plugin.psi.LombokLightClassBuilder;
 import de.plushnikov.intellij.plugin.psi.LombokLightFieldBuilder;
 import de.plushnikov.intellij.plugin.util.LombokProcessorUtil;
 import de.plushnikov.intellij.plugin.util.PsiAnnotationUtil;
+import de.plushnikov.intellij.plugin.util.PsiClassUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class FieldNameConstantsHandler {
 
-  @Nullable
-  public static PsiClass createInnerClassOrEnum(@NotNull PsiClass containingClass, @NotNull PsiAnnotation psiAnnotation, @NotNull Collection<PsiField> psiFIelds) {
-    final String accessLevel = LombokProcessorUtil.getLevelVisibility(psiAnnotation);
-    if (accessLevel == null) {
-      return null;
-    }
-    String typeName = PsiAnnotationUtil.getStringAnnotationValue(psiAnnotation, "innerTypeName");
+  public static String getTypeName(@NotNull PsiClass containingClass, @NotNull PsiAnnotation fieldNameConstants) {
+    String typeName = PsiAnnotationUtil.getStringAnnotationValue(fieldNameConstants, "innerTypeName");
     if (typeName == null || typeName.equals("")) {
       final ConfigDiscovery configDiscovery = ConfigDiscovery.getInstance();
       typeName = configDiscovery.getStringLombokConfigProperty(ConfigKey.FIELD_NAME_CONSTANTS_TYPENAME, containingClass);
     }
+    return typeName;
+  }
+
+  @Nullable
+  public static LombokLightClassBuilder createInnerClassOrEnum(@NotNull String name, @NotNull PsiClass containingClass, @NotNull PsiAnnotation psiAnnotation) {
+    final String accessLevel = LombokProcessorUtil.getLevelVisibility(psiAnnotation);
+    if (accessLevel == null) {
+      return null;
+    }
     final boolean asEnum = PsiAnnotationUtil.getBooleanAnnotationValue(psiAnnotation, "asEnum", false);
     if (asEnum) {
-      return createEnum(typeName, containingClass, psiFIelds, accessLevel, psiAnnotation);
+      return createEnum(name, containingClass, accessLevel, psiAnnotation);
     } else {
-      return createInnerClass(typeName, containingClass, psiFIelds, accessLevel, psiAnnotation);
+      return createInnerClass(name, containingClass, accessLevel, psiAnnotation);
     }
   }
 
+  public static List<PsiField> createFields(@NotNull PsiClass containingClass, @NotNull Collection<PsiField> psiFields) {
+    final Set<String> existingFieldNames = PsiClassUtil.collectClassFieldsIntern(containingClass).stream().map(PsiField::getName).collect(Collectors.toSet());
+    final PsiElementFactory psiElementFactory = JavaPsiFacade.getElementFactory(containingClass.getProject());
+    final PsiClassType classType = psiElementFactory.createType(containingClass);
+    return psiFields.stream().filter(psiField -> !existingFieldNames.contains(psiField.getName()))
+      .map(psiField -> {
+        if (containingClass.isEnum()) {
+          return createEnumConstant(psiField, containingClass, classType);
+        }
+        return createFieldNameConstant(psiField, containingClass);
+      }).collect(Collectors.toList());
+  }
+
   @NotNull
-  private static PsiClass createEnum(@NotNull String name, @NotNull PsiClass containingClass, @NotNull Collection<PsiField> fields, @NotNull String accessLevel, @NotNull PsiElement navigationElement) {
+  private static LombokLightClassBuilder createEnum(@NotNull String name, @NotNull PsiClass containingClass, @NotNull String accessLevel, @NotNull PsiElement navigationElement) {
     final String innerClassQualifiedName = containingClass.getQualifiedName() + "." + name;
     final LombokLightClassBuilder classBuilder = new LombokLightClassBuilder(containingClass, name, innerClassQualifiedName);
     classBuilder.withContainingClass(containingClass)
@@ -45,23 +76,21 @@ public class FieldNameConstantsHandler {
       .withModifier(accessLevel)
       .withImplicitModifier(PsiModifier.STATIC)
       .withImplicitModifier(PsiModifier.FINAL);
-
-    final PsiElementFactory psiElementFactory = JavaPsiFacade.getElementFactory(containingClass.getProject());
-    final PsiClassType classType = psiElementFactory.createType(classBuilder);
-    fields.forEach(field -> {
-      final LombokLightFieldBuilder enumConstantBuilder = new LombokEnumConstantBuilder(containingClass.getManager(), field.getName(), classType)
-        .withContainingClass(containingClass)
-        .withModifier(PsiModifier.PUBLIC)
-        .withImplicitModifier(PsiModifier.STATIC)
-        .withImplicitModifier(PsiModifier.FINAL)
-        .withNavigationElement(field);
-      classBuilder.withField(enumConstantBuilder);
-    });
     return classBuilder;
   }
 
+  private static PsiField createEnumConstant(@NotNull PsiField field, @NotNull PsiClass containingClass, PsiClassType classType) {
+    final LombokLightFieldBuilder enumConstantBuilder = new LombokEnumConstantBuilder(containingClass.getManager(), field.getName(), classType)
+      .withContainingClass(containingClass)
+      .withModifier(PsiModifier.PUBLIC)
+      .withImplicitModifier(PsiModifier.STATIC)
+      .withImplicitModifier(PsiModifier.FINAL)
+      .withNavigationElement(field);
+    return enumConstantBuilder;
+  }
+
   @NotNull
-  private static PsiClass createInnerClass(@NotNull String name, @NotNull PsiClass containingClass, @NotNull Collection<PsiField> psiFields, @NotNull String accessLevel, @NotNull PsiElement navigationElement) {
+  private static LombokLightClassBuilder createInnerClass(@NotNull String name, @NotNull PsiClass containingClass, @NotNull String accessLevel, @NotNull PsiElement navigationElement) {
     final String innerClassQualifiedName = containingClass.getQualifiedName() + "." + name;
     final LombokLightClassBuilder classBuilder = new LombokLightClassBuilder(containingClass, name, innerClassQualifiedName);
     classBuilder.withContainingClass(containingClass)
@@ -69,7 +98,6 @@ public class FieldNameConstantsHandler {
       .withModifier(accessLevel)
       .withModifier(PsiModifier.STATIC)
       .withModifier(PsiModifier.FINAL);
-    psiFields.stream().map(psiField -> createFieldNameConstant(psiField, classBuilder)).forEach(classBuilder::withField);
     return classBuilder;
   }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -105,7 +105,8 @@
     <processor implementation="de.plushnikov.intellij.plugin.processor.clazz.ValueProcessor"/>
 
     <processor implementation="de.plushnikov.intellij.plugin.processor.clazz.UtilityClassProcessor"/>
-    <processor implementation="de.plushnikov.intellij.plugin.processor.clazz.FieldNameConstantsProcessor"/>
+    <processor implementation="de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNameConstantsProcessor"/>
+    <processor implementation="de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNameConstantsPredefinedInnerClassFieldProcessor"/>
 
     <processor implementation="de.plushnikov.intellij.plugin.processor.field.DelegateFieldProcessor"/>
     <processor implementation="de.plushnikov.intellij.plugin.processor.field.GetterFieldProcessor"/>

--- a/src/test/java/de/plushnikov/intellij/plugin/action/delombok/DelombokFieldNameCostantsActionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/action/delombok/DelombokFieldNameCostantsActionTest.java
@@ -18,7 +18,15 @@ public class DelombokFieldNameCostantsActionTest extends LombokLightActionTestCa
     doTest();
   }
 
+  public void testFieldNameConstantsClassHandrolled() throws Exception {
+    doTest();
+  }
+
   public void testFieldNameConstantsEnumClass() throws Exception {
+    doTest();
+  }
+
+  public void testFieldNameConstantsEnumHandrolled() throws Exception {
     doTest();
   }
 

--- a/src/test/java/de/plushnikov/intellij/plugin/processor/FieldNameConstantsTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/processor/FieldNameConstantsTest.java
@@ -15,4 +15,8 @@ public class FieldNameConstantsTest extends AbstractLombokParsingTestCase {
     doTest(true);
   }
 
+  public void testFieldnameconstants$FieldNameConstantsHandrolled() {
+    doTest(true);
+  }
+
 }

--- a/test-manual/src/main/java/de/plushnikov/fieldnameconstants/FieldNameConstantAsEnumHandrolledExample.java
+++ b/test-manual/src/main/java/de/plushnikov/fieldnameconstants/FieldNameConstantAsEnumHandrolledExample.java
@@ -1,0 +1,53 @@
+package de.plushnikov.fieldnameconstants;
+
+import lombok.experimental.FieldNameConstants;
+
+@FieldNameConstants(asEnum = true, innerTypeName = "NAMES")
+public class FieldNameConstantAsEnumExample {
+  private String stringField;
+  private int intField;
+
+  @FieldNameConstants.Exclude
+  private float excluded;
+
+  public int getInt() {
+    return 1;
+  }
+
+  public enum NAMES{
+    existingField
+  }
+
+  public static void main(String[] args) {
+    System.out.println(FieldNameConstantAsEnumExample.NAMES.intField);
+
+    FieldNameConstantAsEnumExample.NAMES iAmAField = NAMES.stringField;
+    System.out.println(iAmAField);
+
+    print(iAmAField);
+    print(NAMES.valueOf("stringField"));
+    print(NAMES.valueOf("intField"));
+    assert iAmAField.compareTo(NAMES.valueOf("stringField")) == 0;
+
+    for (NAMES value : NAMES.values()) {
+      System.out.println("enum name is " + value.name());
+      print(value);
+    }
+
+    assert NAMES.stringField.ordinal() == 0;
+    assert NAMES.intField.ordinal() == 1;
+    assert NAMES.existingField.ordinal() == 2;
+  }
+
+  private static void print(NAMES iAmAField) {
+    switch(iAmAField) {
+      case stringField:
+        System.out.println("stringField");
+        break;
+      case intField:
+        System.out.println("intField");
+        break;
+    }
+  }
+
+}

--- a/testData/action/delombok/fieldnameconstants/afterFieldNameConstantsClassHandrolled.java
+++ b/testData/action/delombok/fieldnameconstants/afterFieldNameConstantsClassHandrolled.java
@@ -1,0 +1,14 @@
+class Test {
+  private float b;
+  private double c;
+  private String d;
+  private String e;
+  private static String f;
+  private static String $g;
+  public static final class Fields {
+    public static final String b = "b";
+    public static final String c = "c";
+    public static final String e = "e";
+    public static final String d = "d";
+  }
+}

--- a/testData/action/delombok/fieldnameconstants/afterFieldNameConstantsEnumHandrolled.java
+++ b/testData/action/delombok/fieldnameconstants/afterFieldNameConstantsEnumHandrolled.java
@@ -1,0 +1,12 @@
+class Test {
+  private float b;
+  private double c;
+  private String d;
+  private String e;
+  private static String f;
+  private static String $g;
+
+  public enum Fields {
+    b, c, e, d
+  }
+}

--- a/testData/action/delombok/fieldnameconstants/beforeFieldNameConstantsClassHandrolled.java
+++ b/testData/action/delombok/fieldnameconstants/beforeFieldNameConstantsClassHandrolled.java
@@ -1,0 +1,13 @@
+@lombok.experimental.FieldNameConstants
+class Test {
+  private float b;
+  private double c;
+  private String d;
+  private String e;
+  private static String f;
+  private static String $g;
+
+  public static final class Fields {
+    public static final String d = "d";
+  }
+}

--- a/testData/action/delombok/fieldnameconstants/beforeFieldNameConstantsEnumHandrolled.java
+++ b/testData/action/delombok/fieldnameconstants/beforeFieldNameConstantsEnumHandrolled.java
@@ -1,0 +1,13 @@
+@lombok.experimental.FieldNameConstants(asEnum = true)
+class Test {
+  private float b;
+  private double c;
+  private String d;
+  private String e;
+  private static String f;
+  private static String $g;
+
+  public enum Fields {
+    d
+  }
+}

--- a/testData/after/fieldnameconstants/FieldNameConstantsHandrolled.java
+++ b/testData/after/fieldnameconstants/FieldNameConstantsHandrolled.java
@@ -1,0 +1,30 @@
+class FieldNameConstantsHandrolled1 {
+  int field1;
+  int alsoAField;
+  int thirdField;
+  public enum TypeTest {
+    alsoAField, thirdField, field1;
+  }
+}
+class FieldNameConstantsHandrolled2 {
+  int field1;
+  int alsoAField;
+  int thirdField;
+  public enum TypeTest {
+    alsoAField, thirdField, field1;
+    public String foo() {
+      return name();
+    }
+  }
+}
+
+class FieldNameConstantsHandrolled3 {
+  int field1;
+  int alsoAField;
+  int thirdField;
+  static class Fields {
+    public static final java.lang.String field1 = "field1";
+    public static final java.lang.String thirdField = "thirdField";
+    public static final int alsoAField = 5;
+  }
+}

--- a/testData/before/fieldnameconstants/FieldNameConstantsHandrolled.java
+++ b/testData/before/fieldnameconstants/FieldNameConstantsHandrolled.java
@@ -1,0 +1,33 @@
+import lombok.experimental.FieldNameConstants;
+import lombok.AccessLevel;
+
+@FieldNameConstants(asEnum = true, innerTypeName = "TypeTest")
+class FieldNameConstantsHandrolled1 {
+  int field1, alsoAField, thirdField;
+
+  public enum TypeTest {
+    field1
+  }
+}
+
+@FieldNameConstants(asEnum = true, innerTypeName = "TypeTest")
+class FieldNameConstantsHandrolled2 {
+  int field1, alsoAField, thirdField;
+
+  public enum TypeTest {
+    field1;
+
+    public String foo() {
+      return name();
+    }
+  }
+}
+
+@FieldNameConstants
+class FieldNameConstantsHandrolled3 {
+  int field1, alsoAField, thirdField;
+
+  static class Fields {
+    public static final int alsoAField = 5;
+  }
+}


### PR DESCRIPTION
…lds with generated values.

Fields that already exist will not be generated. Non existing fields will be generated based on standard FieldNameConstants rules.
Generated output will be before existing fields. This is particularly important in case of enum.
Display warning in case exsiting inner class matches type name of FieldNameConstants but does not also match asEnum.

Hi @mplushnikov . I'm back for round two. Looking forward to any feedback.
Thanks,

Alan