### PR TITLE
Support for the lombok.config option "lombok.toString.callSuper"

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/language/LombokConfigCompletionContributor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/language/LombokConfigCompletionContributor.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 public class LombokConfigCompletionContributor extends CompletionContributor {
 
   private static final String LOMBOK_EQUALS_AND_HASH_CODE_CALL_SUPER = ConfigKey.EQUALSANDHASHCODE_CALL_SUPER.getConfigKey();
+  private static final String LOMBOK_TOSTRING_CALL_SUPER = ConfigKey.TOSTRING_CALL_SUPER.getConfigKey();
 
   public LombokConfigCompletionContributor() {
     final Collection<String> booleanOptions = new HashSet<>(Arrays.asList(
@@ -52,7 +53,7 @@ public class LombokConfigCompletionContributor extends CompletionContributor {
     final Collection<String> otherOptions = new HashSet<>(Arrays.asList(
       ConfigKey.ACCESSORS_PREFIX.getConfigKey(), ConfigKey.LOG_FIELDNAME.getConfigKey(),
       ConfigKey.NONNULL_EXCEPTIONTYPE.getConfigKey(), ConfigKey.EQUALSANDHASHCODE_CALL_SUPER.getConfigKey(),
-      ConfigKey.FIELD_NAME_CONSTANTS_TYPENAME.getConfigKey()));
+      ConfigKey.FIELD_NAME_CONSTANTS_TYPENAME.getConfigKey(), ConfigKey.TOSTRING_CALL_SUPER.getConfigKey()));
 
     final Collection<String> allOptions = new HashSet<>(booleanOptions);
     allOptions.addAll(flagUsageOptions);
@@ -75,7 +76,7 @@ public class LombokConfigCompletionContributor extends CompletionContributor {
             } else if (flagUsageAllowable.contains(configPropertyKey)) {
               resultSet.addElement(LookupElementBuilder.create("ALLOW"));
               resultSet.addElement(LookupElementBuilder.create("WARNING"));
-            } else if (LOMBOK_EQUALS_AND_HASH_CODE_CALL_SUPER.equals(configPropertyKey)) {
+            } else if (LOMBOK_EQUALS_AND_HASH_CODE_CALL_SUPER.equals(configPropertyKey) || LOMBOK_TOSTRING_CALL_SUPER.equals(configPropertyKey) ) {
               resultSet.addElement(LookupElementBuilder.create("CALL"));
               resultSet.addElement(LookupElementBuilder.create("SKIP"));
               resultSet.addElement(LookupElementBuilder.create("WARN"));

--- a/src/main/java/de/plushnikov/intellij/plugin/lombokconfig/ConfigKey.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/lombokconfig/ConfigKey.java
@@ -11,6 +11,7 @@ public enum ConfigKey {
   EQUALSANDHASHCODE_DO_NOT_USE_GETTERS("lombok.equalsAndHashCode.doNotUseGetters", "false"),
   ANYCONSTRUCTOR_SUPPRESS_CONSTRUCTOR_PROPERTIES("lombok.anyConstructor.suppressConstructorProperties", "false"),
 
+  TOSTRING_CALL_SUPER("lombok.toString.callSuper", "skip"),
   TOSTRING_DO_NOT_USE_GETTERS("lombok.toString.doNotUseGetters", "false"),
   TOSTRING_INCLUDE_FIELD_NAMES("lombok.toString.includeFieldNames", "true"),
 

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/ToStringProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/ToStringProcessor.java
@@ -134,7 +134,7 @@ public class ToStringProcessor extends AbstractClassProcessor {
   }
 
   private String createParamString(@NotNull PsiClass psiClass, @NotNull Collection<MemberInfo> memberInfos, @NotNull PsiAnnotation psiAnnotation) {
-    final boolean callSuper = PsiAnnotationUtil.getBooleanAnnotationValue(psiAnnotation, "callSuper", false);
+    final boolean callSuper = readCallSuperAnnotationOrConfigProperty(psiAnnotation, psiClass);
     final boolean doNotUseGetters = readAnnotationOrConfigProperty(psiAnnotation, psiClass, "doNotUseGetters", ConfigKey.TOSTRING_DO_NOT_USE_GETTERS);
     final boolean includeFieldNames = readAnnotationOrConfigProperty(psiAnnotation, psiClass, "includeFieldNames", ConfigKey.TOSTRING_INCLUDE_FIELD_NAMES);
 
@@ -194,5 +194,17 @@ public class ToStringProcessor extends AbstractClassProcessor {
       }
     }
     return LombokPsiElementUsage.NONE;
+  }
+
+  private boolean readCallSuperAnnotationOrConfigProperty(@NotNull PsiAnnotation psiAnnotation, @NotNull PsiClass psiClass) {
+    final boolean result;
+    final Boolean declaredAnnotationValue = PsiAnnotationUtil.getDeclaredBooleanAnnotationValue(psiAnnotation, "callSuper");
+    if (null == declaredAnnotationValue) {
+      final String configProperty = configDiscovery.getStringLombokConfigProperty(ConfigKey.TOSTRING_CALL_SUPER, psiClass);
+      result = PsiClassUtil.hasSuperClass(psiClass) && "CALL".equalsIgnoreCase(configProperty);
+    } else {
+      result = declaredAnnotationValue;
+    }
+    return result;
   }
 }

--- a/src/test/java/de/plushnikov/intellij/plugin/configsystem/ToStringTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/configsystem/ToStringTest.java
@@ -35,4 +35,16 @@ public class ToStringTest extends AbstractLombokConfigSystemTestCase {
   public void testIncludeFieldNames$AnnotationOverwriteTest() throws IOException {
     doTest();
   }
+
+  public void testCallSuper$AnnotationOverwriteTest() throws IOException {
+    doTest();
+  }
+
+  public void testCallSuper$SomeTestWithSuper() throws IOException {
+    doTest();
+  }
+
+  public void testCallSuper$SomeTestWithoutSuper() throws IOException {
+    doTest();
+  }
 }

--- a/testData/configsystem/tostring/callSuper/after/AnnotationOverwriteTest.java
+++ b/testData/configsystem/tostring/callSuper/after/AnnotationOverwriteTest.java
@@ -1,0 +1,32 @@
+public class AnnotationOverwriteTest {
+
+  private int intProperty;
+  private boolean booleanProperty;
+  private double doubleProperty;
+  private String stringProperty;
+
+  public int getIntProperty() {
+    return intProperty;
+  }
+
+  public boolean isBooleanProperty() {
+    return booleanProperty;
+  }
+
+  public double getDoubleProperty() {
+    return doubleProperty;
+  }
+
+  public String getStringProperty() {
+    return stringProperty;
+  }
+
+  public static void main(String[] args) {
+    final AnnotationOverwriteTest test = new AnnotationOverwriteTest();
+    System.out.println(test.hashCode());
+  }
+
+  public String toString() {
+    return "AnnotationOverwriteTest(intProperty=" + this.getIntProperty() + ", booleanProperty=" + this.isBooleanProperty() + ", doubleProperty=" + this.getDoubleProperty() + ", stringProperty=" + this.getStringProperty() + ")";
+  }
+}

--- a/testData/configsystem/tostring/callSuper/after/SomeTestWithSuper.java
+++ b/testData/configsystem/tostring/callSuper/after/SomeTestWithSuper.java
@@ -1,0 +1,44 @@
+import lombok.ToString;
+
+public class Parentclass {
+
+  private String stringProperty;
+
+  public String getStringProperty() {
+    return stringProperty;
+  }
+
+  public String toString() {
+    return "Parentclass(stringProperty=" + this.getStringProperty() + ")";
+  }
+
+}
+
+public class SomeTestWithSuper extends Parentclass {
+  
+  private int intProperty;
+  private boolean booleanProperty;
+  private double doubleProperty;
+
+  public int getIntProperty() {
+    return intProperty;
+  }
+
+  public boolean isBooleanProperty() {
+    return booleanProperty;
+  }
+
+  public double getDoubleProperty() {
+    return doubleProperty;
+  }
+  
+  public static void main(String[] args) {
+    final SomeTest test = new SomeTest();
+    System.out.println(test.hashCode());
+  }
+
+  public String toString() {
+    return "SomeTestWithSuper(super=" + super.toString() + ", intProperty=" + this.getIntProperty() + ", booleanProperty=" + this.isBooleanProperty() + ", doubleProperty=" + this.getDoubleProperty() + ")";
+  }
+
+}

--- a/testData/configsystem/tostring/callSuper/after/SomeTestWithoutSuper.java
+++ b/testData/configsystem/tostring/callSuper/after/SomeTestWithoutSuper.java
@@ -1,0 +1,32 @@
+public class SomeTestWithoutSuper {
+
+  private int intProperty;
+  private boolean booleanProperty;
+  private double doubleProperty;
+  private String stringProperty;
+
+  public int getIntProperty() {
+    return intProperty;
+  }
+
+  public boolean isBooleanProperty() {
+    return booleanProperty;
+  }
+
+  public double getDoubleProperty() {
+    return doubleProperty;
+  }
+
+  public String getStringProperty() {
+    return stringProperty;
+  }
+
+  public static void main(String[] args) {
+    final SomeTest test = new SomeTest();
+    System.out.println(test.hashCode());
+  }
+
+  public String toString() {
+    return "SomeTestWithoutSuper(intProperty=" + this.getIntProperty() + ", booleanProperty=" + this.isBooleanProperty() + ", doubleProperty=" + this.getDoubleProperty() + ", stringProperty=" + this.getStringProperty() + ")";
+  }
+}

--- a/testData/configsystem/tostring/callSuper/before/AnnotationOverwriteTest.java
+++ b/testData/configsystem/tostring/callSuper/before/AnnotationOverwriteTest.java
@@ -1,0 +1,31 @@
+import lombok.ToString;
+
+@ToString(callSuper = skip)
+public class AnnotationOverwriteTest {
+  
+  private int intProperty;
+  private boolean booleanProperty;
+  private double doubleProperty;
+  private String stringProperty;
+
+  public int getIntProperty() {
+    return intProperty;
+  }
+
+  public boolean isBooleanProperty() {
+    return booleanProperty;
+  }
+
+  public double getDoubleProperty() {
+    return doubleProperty;
+  }
+
+  public String getStringProperty() {
+    return stringProperty;
+  }
+
+  public static void main(String[] args) {
+    final AnnotationOverwriteTest test = new AnnotationOverwriteTest();
+    System.out.println(test.hashCode());
+  }
+}

--- a/testData/configsystem/tostring/callSuper/before/SomeTestWithSuper.java
+++ b/testData/configsystem/tostring/callSuper/before/SomeTestWithSuper.java
@@ -1,0 +1,37 @@
+import lombok.ToString;
+
+@ToString
+public class Parentclass {
+
+  private String stringProperty;
+
+  public String getStringProperty() {
+    return stringProperty;
+  }
+
+}
+
+@ToString
+public class SomeTestWithSuper extends Parentclass {
+  
+  private int intProperty;
+  private boolean booleanProperty;
+  private double doubleProperty;
+
+  public int getIntProperty() {
+    return intProperty;
+  }
+
+  public boolean isBooleanProperty() {
+    return booleanProperty;
+  }
+
+  public double getDoubleProperty() {
+    return doubleProperty;
+  }
+
+  public static void main(String[] args) {
+    final SomeTest test = new SomeTest();
+    System.out.println(test.hashCode());
+  }
+}

--- a/testData/configsystem/tostring/callSuper/before/SomeTestWithoutSuper.java
+++ b/testData/configsystem/tostring/callSuper/before/SomeTestWithoutSuper.java
@@ -1,0 +1,31 @@
+import lombok.ToString;
+
+@ToString
+public class SomeTestWithoutSuper {
+  
+  private int intProperty;
+  private boolean booleanProperty;
+  private double doubleProperty;
+  private String stringProperty;
+
+  public int getIntProperty() {
+    return intProperty;
+  }
+
+  public boolean isBooleanProperty() {
+    return booleanProperty;
+  }
+
+  public double getDoubleProperty() {
+    return doubleProperty;
+  }
+
+  public String getStringProperty() {
+    return stringProperty;
+  }
+
+  public static void main(String[] args) {
+    final SomeTest test = new SomeTest();
+    System.out.println(test.hashCode());
+  }
+}

--- a/testData/configsystem/tostring/callSuper/before/lombok.config
+++ b/testData/configsystem/tostring/callSuper/before/lombok.config
@@ -1,0 +1,3 @@
+lombok.toString.callSuper = call
+
+config.stopBubbling = true


### PR DESCRIPTION
I added fundamental support for the lombok.config option "lombok.toString.callSuper".

I think ToStringProcessor should do the same validation call as EqualsAndHashCodeProcessor (validateCallSuperParamIntern, validateCallSuperParamForObject) but I didn't just want to copy&paste those methods. There should be a better place for common validations of both classes (maybe DataProcessor?).