### PR TITLE
Initial support for @CustomLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Developed By
 - [**@bulgakovalexander** Alexander Bulgakov](https://github.com/bulgakovalexander)
 - [**@jeromewaibel** Jérôme Waibel](https://github.com/jeromewaibel)
 - [**@Jessevanbekkum** Jesse van Bekkum](https://github.com/Jessevanbekkum)
+- [**@juriad** Adam Juraszek](https://github.com/juriad)
 - [**@krzyk** Krzysztof Krasoń](https://github.com/krzyk)
 - [**@Lekanich** Aleksandr Lekanich](https://github.com/Lekanich)
 - [**@mg6maciej** Maciej Górski](https://github.com/mg6maciej)

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ copy {
     include 'lombok/AccessLevel.java'
     include 'lombok/*ArgsConstructor.java'
     include 'lombok/Cleanup.java'
+    include 'lombok/CustomLog.java'
     include 'lombok/Data.java'
     include 'lombok/Delegate.java'
     include 'lombok/Getter.java'

--- a/src/main/java/de/plushnikov/intellij/plugin/action/delombok/DelombokEverythingAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/action/delombok/DelombokEverythingAction.java
@@ -24,6 +24,7 @@ import de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNam
 import de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNameConstantsPredefinedInnerClassFieldProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNameConstantsProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.CommonsLogProcessor;
+import de.plushnikov.intellij.plugin.processor.clazz.log.CustomLogProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.FloggerProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.JBossLogProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.Log4j2Processor;
@@ -58,7 +59,7 @@ public class DelombokEverythingAction extends AbstractDelombokAction {
 
       ServiceManager.getService(CommonsLogProcessor.class), ServiceManager.getService(JBossLogProcessor.class), ServiceManager.getService(Log4jProcessor.class),
       ServiceManager.getService(Log4j2Processor.class), ServiceManager.getService(LogProcessor.class), ServiceManager.getService(Slf4jProcessor.class),
-      ServiceManager.getService(XSlf4jProcessor.class), ServiceManager.getService(FloggerProcessor.class),
+      ServiceManager.getService(XSlf4jProcessor.class), ServiceManager.getService(FloggerProcessor.class), ServiceManager.getService(CustomLogProcessor.class),
 
       ServiceManager.getService(GetterFieldProcessor.class),
       ServiceManager.getService(SetterFieldProcessor.class),

--- a/src/main/java/de/plushnikov/intellij/plugin/action/delombok/DelombokLoggerAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/action/delombok/DelombokLoggerAction.java
@@ -2,6 +2,7 @@ package de.plushnikov.intellij.plugin.action.delombok;
 
 import com.intellij.openapi.components.ServiceManager;
 import de.plushnikov.intellij.plugin.processor.clazz.log.CommonsLogProcessor;
+import de.plushnikov.intellij.plugin.processor.clazz.log.CustomLogProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.FloggerProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.JBossLogProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.Log4j2Processor;
@@ -17,6 +18,7 @@ public class DelombokLoggerAction extends AbstractDelombokAction {
     return new DelombokHandler(
       ServiceManager.getService(CommonsLogProcessor.class), ServiceManager.getService(JBossLogProcessor.class),
       ServiceManager.getService(Log4jProcessor.class), ServiceManager.getService(Log4j2Processor.class), ServiceManager.getService(LogProcessor.class),
-      ServiceManager.getService(Slf4jProcessor.class), ServiceManager.getService(XSlf4jProcessor.class), ServiceManager.getService(FloggerProcessor.class));
+      ServiceManager.getService(Slf4jProcessor.class), ServiceManager.getService(XSlf4jProcessor.class), ServiceManager.getService(FloggerProcessor.class),
+      ServiceManager.getService(CustomLogProcessor.class));
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/action/lombok/LombokLoggerHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/action/lombok/LombokLoggerHandler.java
@@ -9,6 +9,7 @@ import com.intellij.psi.PsiModifier;
 import com.intellij.refactoring.rename.RenameProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.AbstractLogProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.CommonsLogProcessor;
+import de.plushnikov.intellij.plugin.processor.clazz.log.CustomLogProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.FloggerProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.JBossLogProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.Log4j2Processor;
@@ -27,14 +28,17 @@ public class LombokLoggerHandler extends BaseLombokHandler {
     final Collection<AbstractLogProcessor> logProcessors = Arrays.asList(
       ServiceManager.getService(CommonsLogProcessor.class), ServiceManager.getService(JBossLogProcessor.class),
       ServiceManager.getService(Log4jProcessor.class), ServiceManager.getService(Log4j2Processor.class), ServiceManager.getService(LogProcessor.class),
-      ServiceManager.getService(Slf4jProcessor.class), ServiceManager.getService(XSlf4jProcessor.class), ServiceManager.getService(FloggerProcessor.class));
+      ServiceManager.getService(Slf4jProcessor.class), ServiceManager.getService(XSlf4jProcessor.class), ServiceManager.getService(FloggerProcessor.class),
+      ServiceManager.getService(CustomLogProcessor.class));
 
     final String lombokLoggerName = AbstractLogProcessor.getLoggerName(psiClass);
     final boolean lombokLoggerIsStatic = AbstractLogProcessor.isLoggerStatic(psiClass);
 
     for (AbstractLogProcessor logProcessor : logProcessors) {
       for (PsiField psiField : psiClass.getFields()) {
-        if (psiField.getType().equalsToText(logProcessor.getLoggerType()) && checkLoggerField(psiField, lombokLoggerName, lombokLoggerIsStatic)) {
+        String loggerType = logProcessor.getLoggerType(psiClass); // null when the custom log's declaration is invalid
+        if (loggerType != null && psiField.getType().equalsToText(loggerType)
+          && checkLoggerField(psiField, lombokLoggerName, lombokLoggerIsStatic)) {
           processLoggerField(psiField, psiClass, logProcessor, lombokLoggerName);
         }
       }
@@ -55,8 +59,8 @@ public class LombokLoggerHandler extends BaseLombokHandler {
   private boolean checkLoggerField(@NotNull PsiField psiField, @NotNull String lombokLoggerName, boolean lombokLoggerIsStatic) {
     if (!isValidLoggerField(psiField, lombokLoggerName, lombokLoggerIsStatic)) {
       int result = Messages.showOkCancelDialog(
-        String.format("Logger field: \"%s\" Is not private %s final field named \"%s\". Refactor anyway?",
-          psiField.getName(), lombokLoggerIsStatic ? "static" : "", lombokLoggerName),
+        String.format("Logger field: \"%s\" Is not private %sfinal field named \"%s\". Refactor anyway?",
+          psiField.getName(), lombokLoggerIsStatic ? "static " : "", lombokLoggerName),
         "Attention!", Messages.getQuestionIcon());
       return DialogWrapper.OK_EXIT_CODE == result;
     }
@@ -69,6 +73,6 @@ public class LombokLoggerHandler extends BaseLombokHandler {
     boolean isFinal = psiField.hasModifierProperty(PsiModifier.FINAL);
     boolean isProperlyNamed = lombokLoggerName.equals(psiField.getName());
 
-    return isPrivate & isStatic & isFinal & isProperlyNamed;
+    return isPrivate && isStatic && isFinal && isProperlyNamed;
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/language/LombokConfigCompletionContributor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/language/LombokConfigCompletionContributor.java
@@ -59,10 +59,11 @@ public class LombokConfigCompletionContributor extends CompletionContributor {
 
     final Collection<String> otherOptions = new HashSet<>(Arrays.asList(
       ConfigKey.ACCESSORS_PREFIX.getConfigKey(), ConfigKey.COPYABLE_ANNOTATIONS.getConfigKey(),
-      ConfigKey.LOG_FIELDNAME.getConfigKey(), ConfigKey.NONNULL_EXCEPTIONTYPE.getConfigKey(),
-      ConfigKey.EQUALSANDHASHCODE_CALL_SUPER.getConfigKey(), ConfigKey.FIELD_NAME_CONSTANTS_PREFIX.getConfigKey(),
-      ConfigKey.FIELD_NAME_CONSTANTS_SUFFIX.getConfigKey(), ConfigKey.FIELD_NAME_CONSTANTS_TYPENAME.getConfigKey(),
-      ConfigKey.FIELD_NAME_CONSTANTS_UPPERCASE.getConfigKey(), ConfigKey.TOSTRING_CALL_SUPER.getConfigKey()));
+      ConfigKey.LOG_FIELDNAME.getConfigKey(), ConfigKey.LOG_CUSTOM_DECLARATION.getConfigKey(),
+      ConfigKey.NONNULL_EXCEPTIONTYPE.getConfigKey(), ConfigKey.EQUALSANDHASHCODE_CALL_SUPER.getConfigKey(),
+      ConfigKey.FIELD_NAME_CONSTANTS_PREFIX.getConfigKey(), ConfigKey.FIELD_NAME_CONSTANTS_SUFFIX.getConfigKey(),
+      ConfigKey.FIELD_NAME_CONSTANTS_TYPENAME.getConfigKey(), ConfigKey.FIELD_NAME_CONSTANTS_UPPERCASE.getConfigKey(),
+      ConfigKey.TOSTRING_CALL_SUPER.getConfigKey()));
 
     final Collection<String> allOptions = new HashSet<>(booleanOptions);
     allOptions.addAll(flagUsageOptions);
@@ -72,7 +73,7 @@ public class LombokConfigCompletionContributor extends CompletionContributor {
     extend(CompletionType.BASIC,
       PsiJavaPatterns.psiElement(LombokConfigTypes.VALUE).withLanguage(LombokConfigLanguage.INSTANCE),
       new CompletionProvider<CompletionParameters>() {
-        public void addCompletions(@NotNull CompletionParameters parameters, ProcessingContext context, @NotNull CompletionResultSet resultSet) {
+        public void addCompletions(@NotNull CompletionParameters parameters, @NotNull ProcessingContext context, @NotNull CompletionResultSet resultSet) {
           PsiElement psiElement = parameters.getPosition().getParent();
           if (psiElement instanceof LombokConfigProperty) {
             final String configPropertyKey = StringUtil.notNullize(LombokConfigPsiUtil.getKey((LombokConfigProperty) psiElement));
@@ -98,7 +99,7 @@ public class LombokConfigCompletionContributor extends CompletionContributor {
     extend(CompletionType.BASIC,
       PsiJavaPatterns.psiElement(LombokConfigTypes.KEY).withLanguage(LombokConfigLanguage.INSTANCE),
       new CompletionProvider<CompletionParameters>() {
-        public void addCompletions(@NotNull CompletionParameters parameters, ProcessingContext context, @NotNull CompletionResultSet resultSet) {
+        public void addCompletions(@NotNull CompletionParameters parameters, @NotNull ProcessingContext context, @NotNull CompletionResultSet resultSet) {
           for (String contribution : allOptions) {
             resultSet.addElement(LookupElementBuilder.create(contribution));
           }

--- a/src/main/java/de/plushnikov/intellij/plugin/lombokconfig/ConfigKey.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/lombokconfig/ConfigKey.java
@@ -8,6 +8,7 @@ public enum ConfigKey {
 
   LOG_FIELDNAME("lombok.log.fieldName", "log"),
   LOG_FIELD_IS_STATIC("lombok.log.fieldIsStatic", "true"),
+  LOG_CUSTOM_DECLARATION("lombok.log.custom.declaration", ""),
 
   EQUALSANDHASHCODE_CALL_SUPER("lombok.equalsAndHashCode.callSuper", "warn"),
   EQUALSANDHASHCODE_DO_NOT_USE_GETTERS("lombok.equalsAndHashCode.doNotUseGetters", "false"),
@@ -60,6 +61,7 @@ public enum ConfigKey {
     GETTER_FLAG_USAGE("lombok.getter.flagUsage", ""),
     GETTER_LAZY_FLAG_USAGE("lombok.getter.lazy.flagUsage", ""),
     LOG_APACHECOMMONS_FLAG_USAGE("lombok.log.apacheCommons.flagUsage", ""),
+    LOG_CUSTOM_USAGE("lombok.log.custom.flagUsage", ""),
     LOG_FLAG_USAGE("lombok.log.flagUsage", ""),
     LOG_JAVAUTILLOGGING_FLAG_USAGE("lombok.log.javaUtilLogging.flagUsage", ""),
     LOG_LOG4J_FLAG_USAGE("lombok.log.log4j.flagUsage", ""),

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/LombokProcessorManager.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/LombokProcessorManager.java
@@ -24,6 +24,7 @@ import de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNam
 import de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNameConstantsPredefinedInnerClassFieldProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.fieldnameconstants.FieldNameConstantsProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.CommonsLogProcessor;
+import de.plushnikov.intellij.plugin.processor.clazz.log.CustomLogProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.FloggerProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.JBossLogProcessor;
 import de.plushnikov.intellij.plugin.processor.clazz.log.Log4j2Processor;
@@ -65,6 +66,7 @@ public class LombokProcessorManager {
       ServiceManager.getService(CommonsLogProcessor.class),
       ServiceManager.getService(JBossLogProcessor.class),
       ServiceManager.getService(FloggerProcessor.class),
+      ServiceManager.getService(CustomLogProcessor.class),
 
       ServiceManager.getService(DataProcessor.class),
       ServiceManager.getService(EqualsAndHashCodeProcessor.class),

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/AbstractSimpleLogProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/AbstractSimpleLogProcessor.java
@@ -1,0 +1,58 @@
+package de.plushnikov.intellij.plugin.processor.clazz.log;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+import com.intellij.psi.PsiClass;
+import org.jetbrains.annotations.NotNull;
+
+abstract class AbstractSimpleLogProcessor extends AbstractLogProcessor {
+  @NotNull
+  private final String loggerType;
+  @NotNull
+  private final String loggerInitializer;
+
+  AbstractSimpleLogProcessor(
+    @NotNull Class<? extends Annotation> supportedAnnotationClass,
+    @NotNull String loggerType,
+    @NotNull String loggerInitializer
+  ) {
+    super(supportedAnnotationClass);
+    this.loggerType = loggerType;
+    this.loggerInitializer = loggerInitializer;
+  }
+
+  @NotNull
+  @Override
+  public final String getLoggerType(@NotNull PsiClass psiClass) {
+    return loggerType;
+  }
+
+  @NotNull
+  @Override
+  final String getLoggerInitializer(@NotNull PsiClass psiClass) {
+    return loggerInitializer;
+  }
+}
+
+abstract class AbstractTopicSupportingSimpleLogProcessor extends AbstractSimpleLogProcessor {
+  @NotNull
+  private final LoggerInitializerParameter defaultParameter;
+
+  AbstractTopicSupportingSimpleLogProcessor(
+    @NotNull Class<? extends Annotation> supportedAnnotationClass,
+    @NotNull String loggerType,
+    @NotNull String loggerInitializer,
+    @NotNull LoggerInitializerParameter defaultParameter
+  ) {
+    super(supportedAnnotationClass, loggerType, loggerInitializer);
+    this.defaultParameter = defaultParameter;
+  }
+
+  @NotNull
+  @Override
+  final List<LoggerInitializerParameter> getLoggerInitializerParameters(@NotNull PsiClass psiClass, boolean topicPresent) {
+    return Collections.singletonList(topicPresent ? LoggerInitializerParameter.TOPIC : defaultParameter);
+  }
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/CommonsLogProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/CommonsLogProcessor.java
@@ -5,13 +5,12 @@ import lombok.extern.apachecommons.CommonsLog;
 /**
  * @author Plushnikov Michail
  */
-public class CommonsLogProcessor extends AbstractLogProcessor {
+public class CommonsLogProcessor extends AbstractTopicSupportingSimpleLogProcessor {
 
   private static final String LOGGER_TYPE = "org.apache.commons.logging.Log";
-  private static final String LOGGER_CATEGORY = "%s.class";
   private static final String LOGGER_INITIALIZER = "org.apache.commons.logging.LogFactory.getLog(%s)";
 
   public CommonsLogProcessor() {
-    super(CommonsLog.class, LOGGER_TYPE, LOGGER_INITIALIZER, LOGGER_CATEGORY);
+    super(CommonsLog.class, LOGGER_TYPE, LOGGER_INITIALIZER, LoggerInitializerParameter.TYPE);
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/CustomLogParser.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/CustomLogParser.java
@@ -1,0 +1,138 @@
+package de.plushnikov.intellij.plugin.processor.clazz.log;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import de.plushnikov.intellij.plugin.processor.clazz.log.AbstractLogProcessor.LoggerInitializerParameter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Never throws exception, returns null in case of invalid declaration.
+ *
+ * @author Adam Juraszek
+ */
+class CustomLogParser {
+  static class LoggerInitializerDeclaration {
+    private final List<LoggerInitializerParameter> withTopic;
+    private final List<LoggerInitializerParameter> withoutTopic;
+
+    LoggerInitializerDeclaration(List<LoggerInitializerParameter> withTopic, List<LoggerInitializerParameter> withoutTopic) {
+      this.withTopic = withTopic;
+      this.withoutTopic = withoutTopic;
+    }
+
+    boolean hasWithTopic() {
+      return withTopic != null;
+    }
+
+    boolean hasWithoutTopic() {
+      return withoutTopic != null;
+    }
+
+    List<LoggerInitializerParameter> get(boolean topicPresent) {
+      return topicPresent ? withTopic : withoutTopic;
+    }
+
+    boolean has(boolean topicPresent) {
+      return (topicPresent ? withTopic : withoutTopic) != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      LoggerInitializerDeclaration that = (LoggerInitializerDeclaration) o;
+      return Objects.equals(withTopic, that.withTopic) && Objects.equals(withoutTopic, that.withoutTopic);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(withTopic, withoutTopic);
+    }
+  }
+
+  // same as in lombok.core.configuration.LogDeclaration
+  private static final Pattern PARAMETERS_PATTERN = Pattern.compile("(?:\\(([A-Z,]*)\\))");
+  private static final Pattern DECLARATION_PATTERN =
+    Pattern.compile("^(?:([^ ]+) )?([^(]+)\\.([^(]+)(" + PARAMETERS_PATTERN.pattern() + "+)$");
+
+  private CustomLogParser() {
+    throw new UnsupportedOperationException("Utility class");
+  }
+
+  @Nullable
+  static String parseLoggerType(@NotNull String customDeclaration) {
+    final Matcher declarationMatcher = DECLARATION_PATTERN.matcher(customDeclaration);
+    if (!declarationMatcher.matches()) {
+      return null;
+    }
+    String loggerType = declarationMatcher.group(1);
+    if (loggerType == null) {
+      loggerType = declarationMatcher.group(2);
+    }
+    return loggerType;
+  }
+
+  @Nullable
+  static String parseLoggerInitializer(@NotNull String customDeclaration) {
+    final Matcher declarationMatcher = DECLARATION_PATTERN.matcher(customDeclaration);
+    if (!declarationMatcher.matches()) {
+      return null;
+    }
+    return declarationMatcher.group(2) + "." + declarationMatcher.group(3) + "(%s)";
+  }
+
+  /**
+   * This method can be used for validating the custom declaration based on returned value.
+   *
+   * @return null if declaration is invalid
+   */
+  @Nullable
+  static LoggerInitializerDeclaration parseInitializerParameters(@NotNull String customDeclaration) {
+    final Matcher declarationMatcher = DECLARATION_PATTERN.matcher(customDeclaration);
+    if (!declarationMatcher.matches()) {
+      return null;
+    }
+
+    List<LoggerInitializerParameter> withTopic = null;
+    List<LoggerInitializerParameter> withoutTopic = null;
+
+    final Matcher allParametersMatcher = PARAMETERS_PATTERN.matcher(declarationMatcher.group(4));
+    while (allParametersMatcher.find()) {
+      final List<LoggerInitializerParameter> splitParameters = splitParameters(allParametersMatcher.group(1));
+      if (splitParameters.contains(LoggerInitializerParameter.UNKNOWN)) {
+        return null;
+      }
+      if (splitParameters.contains(LoggerInitializerParameter.TOPIC)) {
+        if (withTopic != null) {
+          return null;
+        }
+        withTopic = splitParameters;
+      } else {
+        if (withoutTopic != null) {
+          return null;
+        }
+        withoutTopic = splitParameters;
+      }
+    }
+    return new LoggerInitializerDeclaration(withTopic, withoutTopic);
+  }
+
+  @NotNull
+  private static List<LoggerInitializerParameter> splitParameters(@NotNull String parameters) {
+    if (parameters.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return Arrays.stream(parameters.split(",")).map(LoggerInitializerParameter::find).collect(Collectors.toList());
+  }
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/CustomLogProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/CustomLogProcessor.java
@@ -1,0 +1,90 @@
+package de.plushnikov.intellij.plugin.processor.clazz.log;
+
+import java.util.List;
+
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiClass;
+import de.plushnikov.intellij.plugin.lombokconfig.ConfigDiscovery;
+import de.plushnikov.intellij.plugin.lombokconfig.ConfigKey;
+import de.plushnikov.intellij.plugin.problem.ProblemBuilder;
+import de.plushnikov.intellij.plugin.processor.clazz.log.CustomLogParser.LoggerInitializerDeclaration;
+import de.plushnikov.intellij.plugin.util.PsiAnnotationUtil;
+import lombok.CustomLog;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author Adam Juraszek
+ */
+public class CustomLogProcessor extends AbstractLogProcessor {
+
+  public CustomLogProcessor() {
+    super(CustomLog.class);
+  }
+
+  @NotNull
+  private static String getCustomDeclaration(@NotNull PsiClass psiClass) {
+    return ConfigDiscovery.getInstance().getStringLombokConfigProperty(ConfigKey.LOG_CUSTOM_DECLARATION, psiClass);
+  }
+
+  @Nullable
+  @Override
+  public String getLoggerType(@NotNull PsiClass psiClass) {
+    return CustomLogParser.parseLoggerType(getCustomDeclaration(psiClass));
+  }
+
+  @NotNull
+  @Override
+  String getLoggerInitializer(@NotNull PsiClass psiClass) {
+    String loggerInitializer = CustomLogParser.parseLoggerInitializer(getCustomDeclaration(psiClass));
+    if (loggerInitializer == null) {
+      throw new IllegalStateException("Invalid custom log declaration."); // validated
+    }
+    return loggerInitializer;
+  }
+
+  @NotNull
+  @Override
+  List<LoggerInitializerParameter> getLoggerInitializerParameters(@NotNull PsiClass psiClass, boolean topicPresent) {
+    LoggerInitializerDeclaration declaration = CustomLogParser.parseInitializerParameters(getCustomDeclaration(psiClass));
+    if (declaration == null) {
+      throw new IllegalStateException("Invalid custom log declaration."); // validated
+    }
+
+    if (!declaration.has(topicPresent)) {
+      throw new IllegalStateException("@CustomLog is not configured to work " + (topicPresent ? "with" : "without") + " topic.");
+    }
+    return declaration.get(topicPresent);
+  }
+
+  @Override
+  protected boolean validate(
+    @NotNull PsiAnnotation psiAnnotation, @NotNull PsiClass psiClass, @NotNull ProblemBuilder builder
+  ) {
+    if (!super.validate(psiAnnotation, psiClass, builder)) {
+      return false;
+    }
+
+    final LoggerInitializerDeclaration declaration = CustomLogParser.parseInitializerParameters(getCustomDeclaration(psiClass));
+    if (declaration == null) {
+      builder.addError("The @CustomLog is not configured correctly; please set log.custom.declaration in lombok.config.");
+      return false;
+    }
+    final String topic = PsiAnnotationUtil.getStringAnnotationValue(psiAnnotation, "topic");
+    final boolean topicPresent = !StringUtil.isEmptyOrSpaces(topic);
+    if (topicPresent) {
+      if (!declaration.hasWithTopic()) {
+        builder.addError("@CustomLog does not allow a topic.");
+        return false;
+      }
+    } else {
+      if (!declaration.hasWithoutTopic()) {
+        builder.addError("@CustomLog requires a topic.");
+        return false;
+      }
+    }
+    return true;
+  }
+
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/FloggerProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/FloggerProcessor.java
@@ -1,13 +1,26 @@
 package de.plushnikov.intellij.plugin.processor.clazz.log;
 
-import lombok.extern.flogger.Flogger;
+import java.util.Collections;
+import java.util.List;
 
-public class FloggerProcessor extends AbstractLogProcessor {
+import com.intellij.psi.PsiClass;
+import lombok.extern.flogger.Flogger;
+import org.jetbrains.annotations.NotNull;
+
+public class FloggerProcessor extends AbstractSimpleLogProcessor {
   private static final String LOGGER_TYPE = "com.google.common.flogger.FluentLogger";
-  private static final String LOGGER_CATEGORY = "%s.class";
   private static final String LOGGER_INITIALIZER = "com.google.common.flogger.FluentLogger.forEnclosingClass()";
 
   public FloggerProcessor() {
-    super(Flogger.class, LOGGER_TYPE, LOGGER_INITIALIZER, LOGGER_CATEGORY);
+    super(Flogger.class, LOGGER_TYPE, LOGGER_INITIALIZER);
+  }
+
+  @NotNull
+  @Override
+  List<LoggerInitializerParameter> getLoggerInitializerParameters(@NotNull PsiClass psiClass, boolean topicPresent) {
+    if (topicPresent) {
+      throw new IllegalStateException("Flogger does not allow to set a topic.");
+    }
+    return Collections.emptyList();
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/JBossLogProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/JBossLogProcessor.java
@@ -5,13 +5,12 @@ import lombok.extern.jbosslog.JBossLog;
 /**
  * @author Plushnikov Michail
  */
-public class JBossLogProcessor extends AbstractLogProcessor {
+public class JBossLogProcessor extends AbstractTopicSupportingSimpleLogProcessor {
 
   private static final String LOGGER_TYPE = "org.jboss.logging.Logger";
-  private static final String LOGGER_CATEGORY = "%s.class";
   private static final String LOGGER_INITIALIZER = "org.jboss.logging.Logger.getLogger(%s)";
 
   public JBossLogProcessor() {
-    super(JBossLog.class, LOGGER_TYPE, LOGGER_INITIALIZER, LOGGER_CATEGORY);
+    super(JBossLog.class, LOGGER_TYPE, LOGGER_INITIALIZER, LoggerInitializerParameter.TYPE);
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/Log4j2Processor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/Log4j2Processor.java
@@ -5,13 +5,12 @@ import lombok.extern.log4j.Log4j2;
 /**
  * @author Plushnikov Michail
  */
-public class Log4j2Processor extends AbstractLogProcessor {
+public class Log4j2Processor extends AbstractTopicSupportingSimpleLogProcessor {
 
   private static final String LOGGER_TYPE = "org.apache.logging.log4j.Logger";
-  private static final String LOGGER_CATEGORY = "%s.class";
   private static final String LOGGER_INITIALIZER = "org.apache.logging.log4j.LogManager.getLogger(%s)";
 
   public Log4j2Processor() {
-    super(Log4j2.class, LOGGER_TYPE, LOGGER_INITIALIZER, LOGGER_CATEGORY);
+    super(Log4j2.class, LOGGER_TYPE, LOGGER_INITIALIZER, LoggerInitializerParameter.TYPE);
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/Log4jProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/Log4jProcessor.java
@@ -5,13 +5,12 @@ import lombok.extern.log4j.Log4j;
 /**
  * @author Plushnikov Michail
  */
-public class Log4jProcessor extends AbstractLogProcessor {
+public class Log4jProcessor extends AbstractTopicSupportingSimpleLogProcessor {
 
   private static final String LOGGER_TYPE = "org.apache.log4j.Logger";
-  private static final String LOGGER_CATEGORY = "%s.class";
   private static final String LOGGER_INITIALIZER = "org.apache.log4j.Logger.getLogger(%s)";
 
   public Log4jProcessor() {
-    super(Log4j.class, LOGGER_TYPE, LOGGER_INITIALIZER, LOGGER_CATEGORY);
+    super(Log4j.class, LOGGER_TYPE, LOGGER_INITIALIZER, LoggerInitializerParameter.TYPE);
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/LogProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/LogProcessor.java
@@ -5,13 +5,12 @@ import lombok.extern.java.Log;
 /**
  * @author Plushnikov Michail
  */
-public class LogProcessor extends AbstractLogProcessor {
+public class LogProcessor extends AbstractTopicSupportingSimpleLogProcessor {
 
   private static final String LOGGER_TYPE = "java.util.logging.Logger";
-  private static final String LOGGER_CATEGORY = "%s.class.getName()";
   private static final String LOGGER_INITIALIZER = "java.util.logging.Logger.getLogger(%s)";
 
   public LogProcessor() {
-    super(Log.class, LOGGER_TYPE, LOGGER_INITIALIZER, LOGGER_CATEGORY);
+    super(Log.class, LOGGER_TYPE, LOGGER_INITIALIZER, LoggerInitializerParameter.NAME);
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/Slf4jProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/Slf4jProcessor.java
@@ -5,13 +5,12 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * @author Plushnikov Michail
  */
-public class Slf4jProcessor extends AbstractLogProcessor {
+public class Slf4jProcessor extends AbstractTopicSupportingSimpleLogProcessor {
 
   private static final String LOGGER_TYPE = "org.slf4j.Logger";
-  private static final String LOGGER_CATEGORY = "%s.class";
   private static final String LOGGER_INITIALIZER = "org.slf4j.LoggerFactory.getLogger(%s)";
 
   public Slf4jProcessor() {
-    super(Slf4j.class, LOGGER_TYPE, LOGGER_INITIALIZER, LOGGER_CATEGORY);
+    super(Slf4j.class, LOGGER_TYPE, LOGGER_INITIALIZER, LoggerInitializerParameter.TYPE);
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/XSlf4jProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/log/XSlf4jProcessor.java
@@ -5,13 +5,12 @@ import lombok.extern.slf4j.XSlf4j;
 /**
  * @author Plushnikov Michail
  */
-public class XSlf4jProcessor extends AbstractLogProcessor {
+public class XSlf4jProcessor extends AbstractTopicSupportingSimpleLogProcessor {
 
   private static final String LOGGER_TYPE = "org.slf4j.ext.XLogger";
-  private static final String LOGGER_CATEGORY = "%s.class";
   private static final String LOGGER_INITIALIZER = "org.slf4j.ext.XLoggerFactory.getXLogger(%s)";
 
   public XSlf4jProcessor() {
-    super(XSlf4j.class, LOGGER_TYPE, LOGGER_INITIALIZER, LOGGER_CATEGORY);
+    super(XSlf4j.class, LOGGER_TYPE, LOGGER_INITIALIZER, LoggerInitializerParameter.TYPE);
   }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,7 @@
     <applicationService serviceImplementation="de.plushnikov.intellij.plugin.processor.clazz.log.CommonsLogProcessor"/>
     <applicationService serviceImplementation="de.plushnikov.intellij.plugin.processor.clazz.log.JBossLogProcessor"/>
     <applicationService serviceImplementation="de.plushnikov.intellij.plugin.processor.clazz.log.FloggerProcessor"/>
+    <applicationService serviceImplementation="de.plushnikov.intellij.plugin.processor.clazz.log.CustomLogProcessor"/>
 
     <applicationService serviceImplementation="de.plushnikov.intellij.plugin.processor.clazz.DataProcessor"/>
     <applicationService

--- a/src/main/resources/de/plushnikov/intellij/plugin/language/lombokConfig.flex
+++ b/src/main/resources/de/plushnikov/intellij/plugin/language/lombokConfig.flex
@@ -23,7 +23,7 @@ CLEAR="clear"
 KEY_CHARACTER=[^:=\ \n\r\t\f\\] | "\\"{CRLF} | "\\".
 SEPARATOR=[\ \t]* [=] [\ \t]*
 SIGN=[\ \t]* [\-\+]
-VALUE_CHARACTER=[^:=\ \n\r\f\\] | "\\"{CRLF} | "\\".
+VALUE_CHARACTER=[^:=\n\r\f\\] | "\\"{CRLF} | "\\".
 
 %state IN_VALUE
 %state IN_KEY_VALUE_SEPARATOR

--- a/src/test/java/de/plushnikov/intellij/plugin/configsystem/LoggerTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/configsystem/LoggerTest.java
@@ -68,4 +68,13 @@ public class LoggerTest extends AbstractLombokConfigSystemTestCase {
   public void testFieldName$JBossLogTest() throws IOException {
     doTest();
   }
+
+
+  public void testCustomSimple$CustomLogTest() throws IOException {
+    doTest();
+  }
+
+  public void testCustomComplex$CustomLogTest() throws IOException {
+    doTest();
+  }
 }

--- a/src/test/java/de/plushnikov/intellij/plugin/processor/LoggerTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/processor/LoggerTest.java
@@ -54,4 +54,6 @@ public class LoggerTest extends AbstractLombokParsingTestCase {
   public void testLogger$LoggerFlogger() {
     doTest(true);
   }
+
+  // we cannot test CustomLog here because it requires config
 }

--- a/src/test/java/de/plushnikov/intellij/plugin/processor/clazz/log/CustomLogParserTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/processor/clazz/log/CustomLogParserTest.java
@@ -1,0 +1,125 @@
+package de.plushnikov.intellij.plugin.processor.clazz.log;
+
+import java.util.List;
+
+import de.plushnikov.intellij.plugin.processor.clazz.log.AbstractLogProcessor.LoggerInitializerParameter;
+import de.plushnikov.intellij.plugin.processor.clazz.log.CustomLogParser.LoggerInitializerDeclaration;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.FromDataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+@RunWith(Theories.class)
+public class CustomLogParserTest {
+
+  @DataPoints("invalid")
+  public static String[] invalid() {
+    return new String[] {
+      "", "abc", "abc def ()", "C.m()()())", "C C.m(123)"
+    };
+  }
+
+  @DataPoints("invalidButPassing") // lombok itself validates these, do we need to validate them too?
+  public static String[] invalidButPassing() {
+    return new String[] {
+      "123 456.789()", "A   B   .  .  .  ()"
+    };
+  }
+
+  @DataPoints("validType")
+  public static String[] validType() {
+    return new String[] {
+      "A.m()", "A A.m()", "A.m()(NAME,TOPIC)"
+    };
+  }
+
+  @Theory
+  public void parseLoggerTypeInvalid(@FromDataPoints("invalid") String invalid) {
+    assertNull(CustomLogParser.parseLoggerType(invalid));
+  }
+
+  @Theory
+  public void parseLoggerTypeValid(@FromDataPoints("validType") String valid) {
+    assertEquals("A", CustomLogParser.parseLoggerType(valid));
+  }
+
+  @DataPoints("validInitializer")
+  public static String[] validInitializer() {
+    return new String[] {
+      "A B.m()", "B.m()", "B.m(NAME,NULL)(TOPIC)"
+    };
+  }
+
+  @Theory
+  public void parseLoggerInitializerInvalid(@FromDataPoints("invalid") String invalid) {
+    assertNull(CustomLogParser.parseLoggerInitializer(invalid));
+  }
+
+  @Theory
+  public void parseLoggerInitializerValid(@FromDataPoints("validInitializer") String valid) {
+    assertEquals("B.m(%s)", CustomLogParser.parseLoggerInitializer(valid));
+  }
+
+  @Theory
+  public void parseInitializerParametersInvalid(@FromDataPoints("invalid") String invalid) {
+    assertNull(CustomLogParser.parseInitializerParameters(invalid));
+  }
+
+  @DataPoints("invalidParameters")
+  public static String[] invalidParameters() {
+    return new String[] {
+      "B.m(XYZ)", "B.m()()", "B.m(NAME,,NULL)", "B.m(NAME)(NAME,TOPIC)(NULL)", "B.m(NAME)(NAME,TOPIC)(NULL,TOPIC)"
+    };
+  }
+
+  @SuppressWarnings("ArraysAsListWithZeroOrOneArgument") // makes it more symmetric
+  @DataPoints("validParameters")
+  public static T[] validParameters() {
+    return new T[] {
+      t("B.m()", null, asList()),
+      t("B.m(NAME)", null, asList(LoggerInitializerParameter.NAME)),
+      t("B.m(TYPE)", null, asList(LoggerInitializerParameter.TYPE)),
+      t("B.m(NULL)", null, asList(LoggerInitializerParameter.NULL)),
+
+      t("B.m(NAME,NULL,NAME)", null,
+        asList(LoggerInitializerParameter.NAME, LoggerInitializerParameter.NULL, LoggerInitializerParameter.NAME)),
+      t("B.m(NAME,TOPIC)", asList(LoggerInitializerParameter.NAME, LoggerInitializerParameter.TOPIC), null),
+      t("B.m(TOPIC,TOPIC)(NULL)", asList(LoggerInitializerParameter.TOPIC, LoggerInitializerParameter.TOPIC),
+        asList(LoggerInitializerParameter.NULL)),
+      t("B.m()(TOPIC,TYPE)", asList(LoggerInitializerParameter.TOPIC, LoggerInitializerParameter.TYPE), asList())
+    };
+  }
+
+  @Theory
+  public void parseInitializerParametersInvalid2(@FromDataPoints("invalidParameters") String invalid) {
+    assertNull(CustomLogParser.parseInitializerParameters(invalid));
+  }
+
+  @Theory
+  public void parseInitializerParametersValid(@FromDataPoints("validParameters") T valid) {
+    assertEquals(valid.declaration, CustomLogParser.parseInitializerParameters(valid.input));
+  }
+
+  // utils
+
+
+  private static class T {
+    private final String input;
+    private final LoggerInitializerDeclaration declaration;
+
+    T(String input, LoggerInitializerDeclaration declaration) {
+      this.input = input;
+      this.declaration = declaration;
+    }
+  }
+
+  private static T t(String input, List<LoggerInitializerParameter> withTopic, List<LoggerInitializerParameter> withoutTopic) {
+    return new T(input, new LoggerInitializerDeclaration(withTopic, withoutTopic));
+  }
+}

--- a/testData/configsystem/log/customComplex/after/CustomLogTest.java
+++ b/testData/configsystem/log/customComplex/after/CustomLogTest.java
@@ -1,0 +1,23 @@
+import lombok.CustomLog;
+
+public class CustomLogTest {
+  private static final pack.age.Outer.InnerLogger log = pack.age.Outer.Builder.create("outer", null);
+
+  public void logSomething() {
+    log.info("Hello World!");
+  }
+
+  public static void main(String[] args) {
+    log.info("Test");
+    new CustomLogTest().logSomething();
+    new Inner().logSomething();
+  }
+
+  static class Nested {
+    private static final pack.age.Outer.InnerLogger log = pack.age.Outer.Builder.create(Nested.class.getName(), Nested.class, Nested.class.getName());
+
+    public void logSomething() {
+      log.info("Hello World from Nested!");
+    }
+  }
+}

--- a/testData/configsystem/log/customComplex/before/CustomLogTest.java
+++ b/testData/configsystem/log/customComplex/before/CustomLogTest.java
@@ -1,0 +1,22 @@
+import lombok.CustomLog;
+
+@CustomLog(topic = "outer")
+public class CustomLogTest {
+  public void logSomething() {
+    log.info("Hello World!");
+  }
+
+  public static void main(String[] args) {
+    log.info("Test");
+    new CustomLogTest().logSomething();
+    new Inner().logSomething();
+  }
+
+  @CustomLog
+  static class Nested {
+    public void logSomething() {
+      log.info("Hello World from Nested!");
+    }
+  }
+}
+

--- a/testData/configsystem/log/customComplex/before/lombok.config
+++ b/testData/configsystem/log/customComplex/before/lombok.config
@@ -1,0 +1,3 @@
+lombok.log.custom.declaration = pack.age.Outer.InnerLogger pack.age.Outer.Builder.create(TOPIC,NULL)(NAME,TYPE,NAME)
+
+config.stopBubbling = true

--- a/testData/configsystem/log/customSimple/after/CustomLogTest.java
+++ b/testData/configsystem/log/customSimple/after/CustomLogTest.java
@@ -1,0 +1,12 @@
+public class CustomLogTest {
+  private static final MyLogger log = MyLogger.create();
+
+  public void logSomething() {
+    log.info("Hello World!");
+  }
+
+  public static void main(String[] args) {
+    log.info("Test");
+    new CustomLogTest().logSomething();
+  }
+}

--- a/testData/configsystem/log/customSimple/before/CustomLogTest.java
+++ b/testData/configsystem/log/customSimple/before/CustomLogTest.java
@@ -1,0 +1,14 @@
+import lombok.CustomLog;
+
+@CustomLog
+public class CustomLogTest {
+
+  public void logSomething() {
+    log.info("Hello World!");
+  }
+
+  public static void main(String[] args) {
+    log.info("Test");
+    new CustomLogTest().logSomething();
+  }
+}

--- a/testData/configsystem/log/customSimple/before/lombok.config
+++ b/testData/configsystem/log/customSimple/before/lombok.config
@@ -1,0 +1,3 @@
+lombok.log.custom.declaration = MyLogger.create()
+
+config.stopBubbling = true


### PR DESCRIPTION
Since support for @CustomLog (see https://github.com/rzwitserloot/lombok/pull/2086) will be present in the next release of Lombok, I also added it into this Intellij plugin. 

I have tested it briefly, however I have a couple of questions:

* Performance.
  The declaration is a quite complicated expression that requires parsing which can potentially be costly. How often are methods `validate` and `generatePsiElements` called? 
  If there would be a performance problem, we could introduce caching of parsed declaration, but again I don't know if we need to deal with multithreading or even what the cache key should be as the configuration value is found for a psiClass while lombok.config is only one per module.

* Tests
  I couldn't find a way how to unit test the implementation as we need to set lombok.config before the test is performed. Lombok itself allows to define a special comment which sets the configuration. https://github.com/rzwitserloot/lombok/pull/2086/files#diff-336a74e0014249db8ef0ef331af898f8R1 Do we have something similar here?

* License
  Shall I add myself to a list of contributors, or sign something in blood? 

Is there anything that catches your eye, that I should change?