### PR TITLE
Fix @Data and @Value with static constructor and custom constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Developed By
 - [**@toadzky** David Harris](https://github.com/toadzky)
 - [**@twillouer** William Delanoue](https://github.com/twillouer)
 - [**@uvpoblotzki** Ulrich von Poblotzki](https://github.com/uvpoblotzki)
+- [**@vanam** Martin Váňa](https://github.com/vanam)
 - [**@yiftizur** Yiftach Tzur](https://github.com/yiftizur)
 - [**@sluongng** Son Luong Ngoc](https://github.com/sluongng)
 

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/DataProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/DataProcessor.java
@@ -119,13 +119,10 @@ public class DataProcessor extends AbstractClassProcessor {
       final Collection<PsiMethod> definedConstructors = PsiClassUtil.collectClassConstructorIntern(psiClass);
       filterToleratedElements(definedConstructors);
 
-      // and only if there are no any other constructors!
-      if (definedConstructors.isEmpty()) {
-        final Collection<PsiField> requiredFields = requiredArgsConstructorProcessor.getRequiredFields(psiClass);
+      final Collection<PsiField> requiredFields = requiredArgsConstructorProcessor.getRequiredFields(psiClass);
 
-        result = requiredArgsConstructorProcessor.validateIsConstructorNotDefined(
-          psiClass, staticName, requiredFields, ProblemEmptyBuilder.getInstance());
-      }
+      result = requiredArgsConstructorProcessor.validateIsConstructorNotDefined(
+        psiClass, staticName, requiredFields, ProblemEmptyBuilder.getInstance());
     }
     return result;
   }

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/ValueProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/clazz/ValueProcessor.java
@@ -87,14 +87,12 @@ public class ValueProcessor extends AbstractClassProcessor {
       lombok.Builder.class)) {
       final Collection<PsiMethod> definedConstructors = PsiClassUtil.collectClassConstructorIntern(psiClass);
       filterToleratedElements(definedConstructors);
-      // and only if there are no any other constructors!
-      if (definedConstructors.isEmpty()) {
-        final String staticName = PsiAnnotationUtil.getStringAnnotationValue(psiAnnotation, "staticConstructor");
-        final Collection<PsiField> requiredFields = allArgsConstructorProcessor.getAllFields(psiClass);
 
-        if (allArgsConstructorProcessor.validateIsConstructorNotDefined(psiClass, staticName, requiredFields, ProblemEmptyBuilder.getInstance())) {
-          target.addAll(allArgsConstructorProcessor.createAllArgsConstructor(psiClass, PsiModifier.PUBLIC, psiAnnotation, staticName, requiredFields));
-        }
+      final String staticName = PsiAnnotationUtil.getStringAnnotationValue(psiAnnotation, "staticConstructor");
+      final Collection<PsiField> requiredFields = allArgsConstructorProcessor.getAllFields(psiClass);
+
+      if (allArgsConstructorProcessor.validateIsConstructorNotDefined(psiClass, staticName, requiredFields, ProblemEmptyBuilder.getInstance())) {
+        target.addAll(allArgsConstructorProcessor.createAllArgsConstructor(psiClass, PsiModifier.PUBLIC, psiAnnotation, staticName, requiredFields));
       }
     }
 

--- a/src/test/java/de/plushnikov/intellij/plugin/processor/DataTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/processor/DataTest.java
@@ -44,6 +44,14 @@ public class DataTest extends AbstractLombokParsingTestCase {
     doTest(true);
   }
 
+  public void testData$DataStaticConstructor2() {
+    doTest(true);
+  }
+
+  public void testData$DataStaticConstructor3() {
+    doTest(true);
+  }
+
   public void testData$DataWithGeneric176() {
     doTest(true);
   }

--- a/src/test/java/de/plushnikov/intellij/plugin/processor/ValueTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/processor/ValueTest.java
@@ -24,6 +24,10 @@ public class ValueTest extends AbstractLombokParsingTestCase {
     doTest(true);
   }
 
+  public void testValue$ValueStaticConstructor() {
+    doTest(true);
+  }
+
   public void testValue$ValueBuilder() {
     doTest(true);
   }

--- a/testData/after/data/DataStaticConstructor2.java
+++ b/testData/after/data/DataStaticConstructor2.java
@@ -1,0 +1,57 @@
+public class DataStaticConstructor2 {
+  private int privateInt;
+  private final int privateFinalInt;
+
+  // Custom private constructor
+  private DataStaticConstructor2(int privateFinalInt) {
+    this.privateInt = 5;
+    this.privateFinalInt = privateFinalInt;
+  }
+
+  public static void main(String[] args) {
+    final DataStaticConstructor2 test = new DataStaticConstructor2.of(5);
+    System.out.println(test);
+  }
+
+  public static DataStaticConstructor2 of(final int privateFinalInt) {
+    return new DataStaticConstructor2(privateFinalInt);
+  }
+
+  public int getPrivateInt() {
+    return this.privateInt;
+  }
+
+  public int getPrivateFinalInt() {
+    return this.privateFinalInt;
+  }
+
+  public void setPrivateInt(int privateInt) {
+    this.privateInt = privateInt;
+  }
+
+  public boolean equals(final Object o) {
+    if (o == this) return true;
+    if (!(o instanceof DataStaticConstructor2)) return false;
+    final DataStaticConstructor2 other = (DataStaticConstructor2) o;
+    if (!other.canEqual((Object) this)) return false;
+    if (this.privateInt != other.privateInt) return false;
+    if (this.privateFinalInt != other.privateFinalInt) return false;
+    return true;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DataStaticConstructor2;
+  }
+
+  public int hashCode() {
+    final int PRIME = 59;
+    int result = 1;
+    result = result * PRIME + this.privateInt;
+    result = result * PRIME + this.privateFinalInt;
+    return result;
+  }
+
+  public String toString() {
+    return "DataStaticConstructor2(privateInt=" + this.privateInt + ", privateFinalInt=" + this.privateFinalInt + ")";
+  }
+}

--- a/testData/after/data/DataStaticConstructor3.java
+++ b/testData/after/data/DataStaticConstructor3.java
@@ -1,0 +1,49 @@
+public class DataStaticConstructor3 {
+  private int privateInt;
+
+  // Custom private constructor
+  private DataStaticConstructor3() {
+    this.privateInt = 5;
+  }
+
+  public static void main(String[] args) {
+    final DataStaticConstructor3 test = new DataStaticConstructor3.of();
+    System.out.println(test);
+  }
+
+  public static DataStaticConstructor3 of() {
+    return new DataStaticConstructor3();
+  }
+
+  public int getPrivateInt() {
+    return this.privateInt;
+  }
+
+  public void setPrivateInt(int privateInt) {
+    this.privateInt = privateInt;
+  }
+
+  public boolean equals(final Object o) {
+    if (o == this) return true;
+    if (!(o instanceof DataStaticConstructor3)) return false;
+    final DataStaticConstructor3 other = (DataStaticConstructor3) o;
+    if (!other.canEqual((Object) this)) return false;
+    if (this.privateInt != other.privateInt) return false;
+    return true;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof DataStaticConstructor3
+  }
+
+  public int hashCode() {
+    final int PRIME = 59;
+    int result = 1;
+    result = result * PRIME + this.privateInt;
+    return result;
+  }
+
+  public String toString() {
+    return "DataStaticConstructor3(privateInt=" + this.privateInt + ")";
+  }
+}

--- a/testData/after/value/ValueStaticConstructor.java
+++ b/testData/after/value/ValueStaticConstructor.java
@@ -1,0 +1,40 @@
+public final class ValueStaticConstructor {
+  private final int privateInt;
+
+  // Custom private constructor
+  private ValueStaticConstructor(int privateInt) {
+    this.privateInt = -privateInt;
+  }
+
+  public static void main(String[] args) {
+    final ValueStaticConstructor test = new ValueStaticConstructor.of(1);
+    System.out.println(test);
+  }
+
+  public static ValueStaticConstructor of(final int privateInt) {
+    return new ValueStaticConstructor(privateInt);
+  }
+
+  public int getPrivateInt() {
+    return this.privateInt;
+  }
+
+  public boolean equals(final Object o) {
+    if (o == this) return true;
+    if (!(o instanceof ValueStaticConstructor)) return false;
+    final ValueStaticConstructor other = (ValueStaticConstructor) o;
+    if (this.getPrivateInt() != other.getPrivateInt()) return false;
+    return true;
+  }
+
+  public int hashCode() {
+    final int PRIME = 59;
+    int result = 1;
+    result = result * PRIME + this.getPrivateInt();
+    return result;
+  }
+
+  public String toString() {
+    return "ValueStaticConstructor(privateInt=" + this.getPrivateInt() + ")";
+  }
+}

--- a/testData/before/data/DataStaticConstructor2.java
+++ b/testData/before/data/DataStaticConstructor2.java
@@ -1,0 +1,18 @@
+import lombok.Data;
+
+@Data(staticConstructor="of")
+public class DataStaticConstructor2 {
+  private int privateInt;
+  private final int privateFinalInt;
+
+  // Custom private constructor
+  private DataStaticConstructor2(int privateFinalInt) {
+    this.privateInt = 5;
+    this.privateFinalInt = privateFinalInt;
+  }
+
+  public static void main(String[] args) {
+    final DataStaticConstructor2 test = new DataStaticConstructor2.of();
+    System.out.println(test);
+  }
+}

--- a/testData/before/data/DataStaticConstructor3.java
+++ b/testData/before/data/DataStaticConstructor3.java
@@ -1,0 +1,16 @@
+import lombok.Data;
+
+@Data(staticConstructor="of")
+public class DataStaticConstructor3 {
+  private int privateInt;
+
+  // Custom private constructor
+  private DataStaticConstructor3() {
+    this.privateInt = 5;
+  }
+
+  public static void main(String[] args) {
+    final DataStaticConstructor3 test = new DataStaticConstructor3.of();
+    System.out.println(test);
+  }
+}

--- a/testData/before/value/ValueStaticConstructor.java
+++ b/testData/before/value/ValueStaticConstructor.java
@@ -1,0 +1,16 @@
+import lombok.Value;
+
+@Value(staticConstructor="of")
+public class ValueStaticConstructor {
+  private int privateInt;
+
+  // Custom private constructor
+  private ValueStaticConstructor(int privateInt) {
+    this.privateInt = -privateInt;
+  }
+
+  public static void main(String[] args) {
+    final ValueStaticConstructor test = new ValueStaticConstructor.of(1);
+    System.out.println(test);
+  }
+}


### PR DESCRIPTION
Hi,
here is a fix for a `@Data` and `@Value` with static constructor and custom constructor.

Example:
```java
import lombok.Value;

import org.apache.commons.validator.routines.EmailValidator;

@Value(staticConstructor="of")
public class Email {

    private final String value;

    private Email(String value) {
        if (!EmailValidator.getInstance().isValid(value)) {
            throw new IllegalArgumentException();
        }

        this.value = value;
    }

    @Override
    public String toString() {
        return value;
    }
}
```

and

```java
import lombok.Data;

@Data(staticConstructor = "of")
public class ExampleData {
    private int a;

    private final int b;

    private ExampleData(int b) {
        this.a = 5;
        this.b = b;
    }

}
```

In both cases, IDE cannot resolve such method but following tests pass:

```java
import static org.junit.jupiter.api.Assertions.assertThrows;

import org.junit.jupiter.api.Test;

class EmailTest {
    
    @Test
    void of() {
        Email.of("validni@email.com");
    }

    @Test
    void ofInvalid() {
        assertThrows(IllegalArgumentException.class, () -> Email.of("nevalidniemail.com"));
    }
}
```

```java
import org.junit.jupiter.api.Test;

import static org.junit.jupiter.api.Assertions.assertEquals;

class ExampleDataTest {

    @Test
    void of() {
        assertEquals(5, ExampleData.of(6).getA());
        assertEquals(6, ExampleData.of(6).getB());
    }

}
```

Tested with:
* Java 12
* InteliJ Ultimate 2019.2.3
* IntelliJ Lombok plugin 0.27-2019.2
* Lombok 1.18.10