### PR TITLE
Register SneakyThrows quick fix for catching multiple exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Developed By
 - [**@Jessevanbekkum** Jesse van Bekkum](https://github.com/Jessevanbekkum)
 - [**@juriad** Adam Juraszek](https://github.com/juriad)
 - [**@krzyk** Krzysztof Krasoń](https://github.com/krzyk)
-- [**@Lekanich** Aleksandr Lekanich](https://github.com/Lekanich)
+- [**@Lekanich** Aleksandr Zhelezniak](https://github.com/Lekanich)
 - [**@mg6maciej** Maciej Górski](https://github.com/mg6maciej)
 - [**@mlueders** Mike Lueders](https://github.com/mlueders)
 - [**@RohanTalip** Rohan Talip](https://github.com/RohanTalip)

--- a/parts/pluginChanges.html
+++ b/parts/pluginChanges.html
@@ -5,9 +5,9 @@
   </li>
   <li>0.28
     <ol>
-      <li>Fixed #394: New feature request: Add SneakyThrows QuickFix, thanks to @Lekanich (Aleksandr Lekanich)</li>
-      <li>Fixed #440: NPE inspection false positive with lazy getters, thanks to @Lekanich (Aleksandr Lekanich)</li>
-      <li>Fixed #633: @Builder.Default causes a warning message, thanks to @Lekanich (Aleksandr Lekanich)</li>
+      <li>Fixed #394: New feature request: Add SneakyThrows QuickFix, thanks to @Lekanich (Aleksandr Zhelezniak)</li>
+      <li>Fixed #440: NPE inspection false positive with lazy getters, thanks to @Lekanich (Aleksandr Zhelezniak)</li>
+      <li>Fixed #633: @Builder.Default causes a warning message, thanks to @Lekanich (Aleksandr Zhelezniak)</li>
       <li>Fixed #672: Add support for @CustomLog, thanks to @juriad (Adam Juraszek)</li>
       <li>Fixed #687: Support static constructors using already-defined private constructors, thanks to @vanam (Martin
         Váňa)

--- a/src/main/java/de/plushnikov/intellij/plugin/extension/LombokHighlightErrorFilter.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/extension/LombokHighlightErrorFilter.java
@@ -102,7 +102,7 @@ public class LombokHighlightErrorFilter implements HighlightInfoFilter {
   private enum LombokHighlightFixHook {
 
     UNHANDLED_EXCEPTION(HighlightSeverity.ERROR, CodeInsightColors.ERRORS_ATTRIBUTES) {
-      private final Pattern pattern = Pattern.compile("Unhandled exception: .+");
+      private final Pattern pattern = Pattern.compile("Unhandled exceptions?: .+");
 
       @Override
       public boolean descriptionCheck(@Nullable String description) {

--- a/src/test/java/de/plushnikov/intellij/plugin/extension/SneakyThrowsExceptionAddQuickFixTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/extension/SneakyThrowsExceptionAddQuickFixTest.java
@@ -23,6 +23,14 @@ public class SneakyThrowsExceptionAddQuickFixTest extends AbstractLombokLightCod
       availableActions.stream().anyMatch(action -> action.getText().contains("@SneakyThrows")));
   }
 
+  public void testCheckedMultipleExceptionQuickFixExample() {
+    myFixture.configureByFile(getBasePath() + '/' + getTestName(false) + ".java");
+
+    final List<IntentionAction> availableActions = getAvailableActions();
+    assertTrue("Intention to add @SneakyThrows was not presented",
+      availableActions.stream().anyMatch(action -> action.getText().contains("@SneakyThrows")));
+  }
+
   protected List<IntentionAction> getAvailableActions() {
     final Editor editor = getEditor();
     final PsiFile file = getFile();

--- a/testData/extension/CheckedMultipleExceptionQuickFixExample.java
+++ b/testData/extension/CheckedMultipleExceptionQuickFixExample.java
@@ -1,0 +1,10 @@
+package extension;
+
+import java.io.IOException;
+
+public class CheckedMultipleExceptionQuickFixExample {
+
+  public static void main(String[] args) {
+    CheckedMultipleExceptionQuickFixExample.class.<caret>newInstance();
+  }
+}


### PR DESCRIPTION
Added quick fix also for catching a few exceptions. 
An improved pattern for matching the right message for SneakyThrows exceptions.