### PR TITLE
Only delete getters that have the canonical form

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/action/lombok/LombokGetterHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/action/lombok/LombokGetterHandler.java
@@ -3,7 +3,6 @@ package de.plushnikov.intellij.plugin.action.lombok;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiMethod;
-import com.intellij.psi.PsiModifier;
 import com.intellij.psi.util.PropertyUtil;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
@@ -15,11 +14,10 @@ public class LombokGetterHandler extends BaseLombokHandler {
 
   protected void processClass(@NotNull PsiClass psiClass) {
     final Map<PsiField, PsiMethod> fieldMethodMap = new HashMap<>();
-    for (PsiField psiField : psiClass.getFields()) {
-      PsiMethod propertyGetter = PropertyUtil.findPropertyGetter(psiClass, psiField.getName(), psiField.hasModifierProperty(PsiModifier.STATIC), false);
-
-      if (null != propertyGetter) {
-        fieldMethodMap.put(psiField, propertyGetter);
+    for (PsiField field : psiClass.getFields()) {
+      PsiMethod getter = PropertyUtil.findGetterForField(field);
+      if (PropertyUtil.getFieldOfGetter(getter) == field) {
+        fieldMethodMap.put(field, getter);
       }
     }
 

--- a/testData/action/lombok/getter/afterGetterSimple.java
+++ b/testData/action/lombok/getter/afterGetterSimple.java
@@ -6,4 +6,23 @@ class Test {
   private double c;
   private String d;
 
+  private int wrongReturnType;
+  private int wrongField;
+  private int fieldWithoutGetter;
+  private int sideEffect;
+  private int javadoc;
+  private int comment;
+
+  public long getWrongReturnType() {
+    return wrongReturnType;
+  }
+
+  public int getWrongField() {
+    return wrongReturnType;
+  }
+
+  public int getSideEffect() {
+    System.out.println("side-effect");
+    return sideEffect;
+  }
 }

--- a/testData/action/lombok/getter/beforeGetterSimple.java
+++ b/testData/action/lombok/getter/beforeGetterSimple.java
@@ -3,6 +3,13 @@ class Test {
   private double c;
   private String d;
 
+  private int wrongReturnType;
+  private int wrongField;
+  private int fieldWithoutGetter;
+  private int sideEffect;
+  private int javadoc;
+  private int comment;
+
   public float getB() {
     return b;
   }
@@ -13,5 +20,28 @@ class Test {
 
   public String getD() {
     return d;
+  }
+
+  public long getWrongReturnType() {
+    return wrongReturnType;
+  }
+
+  public int getWrongField() {
+    return wrongReturnType;
+  }
+
+  public int getSideEffect() {
+    System.out.println("side-effect");
+    return sideEffect;
+  }
+
+  /** Javadoc. */
+  public int getJavadoc() {
+    return javadoc;
+  }
+
+  public int getComment() {
+    // An implementation comment.
+    return comment;
   }
 }


### PR DESCRIPTION
https://github.com/mplushnikov/lombok-intellij-plugin/issues/688

This is just a proof of concept, to get some early feedback.

Of course the same work would have to be done for the setters as well.

And maybe for the equals and hashCode methods. It might get trickier to test whether these are of the few established standard forms, as produced by Eclipse, IntelliJ and a few other IDEs.

My main focus are the getters and setters for now since manually checking for typos in that code is absolutely boring and error-prone.

While testing I noticed that Lombok will add a getter for `fieldWithoutGetter`. This may be intentional or not.