### PR TITLE
On test failure, show actual file content in the diff

### DIFF
--- a/src/test/java/de/plushnikov/intellij/plugin/AbstractLombokLightCodeInsightTestCase.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/AbstractLombokLightCodeInsightTestCase.java
@@ -58,7 +58,9 @@ public abstract class AbstractLombokLightCodeInsightTestCase extends LightJavaCo
       final String path = getTestDataPath() + "/" + expectedFile;
       String expectedFileText = StringUtil.convertLineSeparators(FileUtil.loadFile(new File(path)));
 
-      assertEquals(expectedFileText.replaceAll("\\s+", ""), actualFileText.replaceAll("\\s+", ""));
+      if (!expectedFileText.replaceAll("\\s+", "").equals(actualFileText.replaceAll("\\s+", ""))) {
+        assertEquals(expectedFileText, actualFileText);
+      }
     }
   }
 }


### PR DESCRIPTION
This makes the failure message easier to read, especially when using the
Diff viewer in IntelliJ.