### PR TITLE
Accessor identifier can start from a number.

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/processor/field/AccessorsInfo.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/field/AccessorsInfo.java
@@ -174,8 +174,10 @@ public class AccessorsInfo {
 
   private boolean canPrefixApply(String fieldName, String prefix) {
     final int prefixLength = prefix.length();
-    return prefixLength == 0 || fieldName.startsWith(prefix) && fieldName.length() > prefixLength &&
-      (!Character.isLetter(prefix.charAt(prefix.length() - 1)) || Character.isUpperCase(fieldName.charAt(prefixLength)) || Character.isDigit(fieldName.charAt(prefixLength)));
+    // we can use digits and upper case letters after a prefix, but not lower case letters
+    return prefixLength == 0 ||
+      fieldName.startsWith(prefix) && fieldName.length() > prefixLength &&
+        (!Character.isLetter(prefix.charAt(prefix.length() - 1)) || !Character.isLowerCase(fieldName.charAt(prefixLength)));
   }
 
   private String decapitalizeLikeLombok(String name) {

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/field/AccessorsInfo.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/field/AccessorsInfo.java
@@ -175,7 +175,7 @@ public class AccessorsInfo {
   private boolean canPrefixApply(String fieldName, String prefix) {
     final int prefixLength = prefix.length();
     return prefixLength == 0 || fieldName.startsWith(prefix) && fieldName.length() > prefixLength &&
-      (!Character.isLetter(prefix.charAt(prefix.length() - 1)) || Character.isUpperCase(fieldName.charAt(prefixLength)));
+      (!Character.isLetter(prefix.charAt(prefix.length() - 1)) || Character.isUpperCase(fieldName.charAt(prefixLength)) || Character.isDigit(fieldName.charAt(prefixLength)));
   }
 
   private String decapitalizeLikeLombok(String name) {

--- a/test-manual/src/main/java/de/plushnikov/accessors/AccessorNumericStartIssue724.java
+++ b/test-manual/src/main/java/de/plushnikov/accessors/AccessorNumericStartIssue724.java
@@ -1,7 +1,7 @@
 package de.plushnikov.accessors;
 
-  import lombok.Getter;
-  import lombok.experimental.Accessors;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 
 @Accessors(prefix = "m")
 public class AccessorNumericStartIssue724 {

--- a/test-manual/src/main/java/de/plushnikov/accessors/AccessorNumericStartIssue724.java
+++ b/test-manual/src/main/java/de/plushnikov/accessors/AccessorNumericStartIssue724.java
@@ -1,0 +1,11 @@
+package de.plushnikov.accessors;
+
+  import lombok.Getter;
+  import lombok.experimental.Accessors;
+
+@Accessors(prefix = "m")
+public class AccessorNumericStartIssue724 {
+  @Getter
+  private float m3Titanic;
+}
+

--- a/testData/after/accessors/Accessors.java
+++ b/testData/after/accessors/Accessors.java
@@ -168,3 +168,11 @@ class AccessorsFluentStatic<T extends Number> {
 		AccessorsFluentStatic.name = name;
 	}
 }
+
+class AccessorNumericStartIssue724 {
+  private float m3Titanic;
+
+  public float get3Titanic() {
+    return this.m3Titanic;
+  }
+}

--- a/testData/before/accessors/Accessors.java
+++ b/testData/before/accessors/Accessors.java
@@ -31,7 +31,7 @@ class AccessorsPrefix2 {
 @lombok.EqualsAndHashCode
 class AccessorsPrefix3 {
 	private String fName;
-	
+
 	private String getName() {
 		return fName;
 	}
@@ -56,4 +56,10 @@ class AccessorsFluentNoChaining {
 
 class AccessorsFluentStatic<T extends Number> {
 	@lombok.Setter @lombok.experimental.Accessors(fluent=true) private static String name;
+}
+
+@lombok.experimental.Accessors(prefix = "m")
+class AccessorNumericStartIssue724 {
+  @lombok.Getter
+  private float m3Titanic;
 }


### PR DESCRIPTION
Fix for issue #724 
@Accessors with prefix can break with numbers.
Added additional check for pass digits as a possible start for custom accessors.