### PR TITLE
Add UtilityClass check to FieldDefaultsModifierProcessor, fixes #735

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/processor/modifier/FieldDefaultsModifierProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/modifier/FieldDefaultsModifierProcessor.java
@@ -51,7 +51,7 @@ public class FieldDefaultsModifierProcessor implements ModifierProcessor {
 
   @Override
   public void transformModifiers(@NotNull PsiModifierList modifierList, @NotNull final Set<String> modifiers) {
-    if (modifiers.contains(PsiModifier.STATIC)) {
+    if (UtilityClassModifierProcessor.isModifierListSupported(modifierList) || modifiers.contains(PsiModifier.STATIC)) {
       return; // skip static fields
     }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/modifier/FieldDefaultsModifierProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/modifier/FieldDefaultsModifierProcessor.java
@@ -51,7 +51,7 @@ public class FieldDefaultsModifierProcessor implements ModifierProcessor {
 
   @Override
   public void transformModifiers(@NotNull PsiModifierList modifierList, @NotNull final Set<String> modifiers) {
-    if (UtilityClassModifierProcessor.isModifierListSupported(modifierList) || modifiers.contains(PsiModifier.STATIC)) {
+    if (modifiers.contains(PsiModifier.STATIC) || UtilityClassModifierProcessor.isModifierListSupported(modifierList)) {
       return; // skip static fields
     }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/processor/modifier/UtilityClassModifierProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/modifier/UtilityClassModifierProcessor.java
@@ -20,8 +20,7 @@ import java.util.Set;
  */
 public class UtilityClassModifierProcessor implements ModifierProcessor {
 
-  @Override
-  public boolean isSupported(@NotNull PsiModifierList modifierList) {
+  public static boolean isModifierListSupported(@NotNull PsiModifierList modifierList) {
     PsiElement modifierListParent = modifierList.getParent();
 
     if (modifierListParent instanceof PsiClass) {
@@ -38,6 +37,11 @@ public class UtilityClassModifierProcessor implements ModifierProcessor {
     PsiClass searchableClass = PsiTreeUtil.getParentOfType(modifierListParent, PsiClass.class, true);
 
     return null != searchableClass && PsiAnnotationSearchUtil.isAnnotatedWith(searchableClass, UtilityClass.class) && UtilityClassProcessor.validateOnRightType(searchableClass, new ProblemNewBuilder());
+  }
+
+  @Override
+  public boolean isSupported(@NotNull PsiModifierList modifierList) {
+    return isModifierListSupported(modifierList);
   }
 
   @Override
@@ -58,7 +62,7 @@ public class UtilityClassModifierProcessor implements ModifierProcessor {
     }
   }
 
-  private boolean isElementFieldOrMethodOrInnerClass(PsiElement element) {
+  private static boolean isElementFieldOrMethodOrInnerClass(PsiElement element) {
     return element instanceof PsiField || element instanceof PsiMethod ||
       (element instanceof PsiClass && element.getParent() instanceof PsiClass && !((PsiClass) element.getParent()).isInterface());
   }

--- a/src/test/java/de/plushnikov/intellij/plugin/processor/modifier/FieldDefaultsModifierTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/processor/modifier/FieldDefaultsModifierTest.java
@@ -129,6 +129,13 @@ public class FieldDefaultsModifierTest extends AbstractLombokLightCodeInsightTes
     assertTrue("@FieldDefaults should keep explicit modifier intact", modifierList.hasModifierProperty(PsiModifier.PROTECTED));
   }
 
+  public void testFieldDefaultsWithUtilityClass() {
+
+    PsiModifierList modifierList = getFieldModifierListAtCaret();
+
+    assertFalse("@FieldDefaults(makeFinal = true) should not make @UtilityClass fields final", modifierList.hasModifierProperty(PsiModifier.FINAL));
+  }
+
   //</editor-fold>
 
   //<editor-fold desc="Internal support methods">

--- a/src/test/java/de/plushnikov/intellij/plugin/processor/modifier/FieldDefaultsModifierTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/processor/modifier/FieldDefaultsModifierTest.java
@@ -60,6 +60,13 @@ public class FieldDefaultsModifierTest extends AbstractLombokLightCodeInsightTes
     assertFalse("@FieldDefaults(makeFinal = true) should not make @NonFinal fields final", modifierList.hasModifierProperty(PsiModifier.FINAL));
   }
 
+  public void testFieldDefaultsWithUtilityClass() {
+
+    PsiModifierList modifierList = getFieldModifierListAtCaret();
+
+    assertFalse("@FieldDefaults(makeFinal = true) should not make @UtilityClass fields final", modifierList.hasModifierProperty(PsiModifier.FINAL));
+  }
+
   //</editor-fold>
 
   //<editor-fold desc="Handling of visibility modifiers">
@@ -127,13 +134,6 @@ public class FieldDefaultsModifierTest extends AbstractLombokLightCodeInsightTes
 
     assertFalse("@FieldDefaults should not touch fields with explicit modifier", modifierList.hasModifierProperty(PsiModifier.PUBLIC));
     assertTrue("@FieldDefaults should keep explicit modifier intact", modifierList.hasModifierProperty(PsiModifier.PROTECTED));
-  }
-
-  public void testFieldDefaultsWithUtilityClass() {
-
-    PsiModifierList modifierList = getFieldModifierListAtCaret();
-
-    assertFalse("@FieldDefaults(makeFinal = true) should not make @UtilityClass fields final", modifierList.hasModifierProperty(PsiModifier.FINAL));
   }
 
   //</editor-fold>

--- a/testData/augment/modifier/FieldDefaultsWithUtilityClass.java
+++ b/testData/augment/modifier/FieldDefaultsWithUtilityClass.java
@@ -1,0 +1,9 @@
+import lombok.experimental.UtilityClass;
+import lombok.experimental.FieldDefaults;
+import lombok.AccessLevel;
+
+@UtilityClass
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class FieldDefaultsWithUtilityClass {
+  private boolean myStaticField<caret>;
+}


### PR DESCRIPTION
Checks if field will be made static or is already static so the "not initialized" error doesn't show up anymore. (#735)