### PR TITLE
Facilitate user experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Developed By
 - [**@yiftizur** Yiftach Tzur](https://github.com/yiftizur)
 - [**@sluongng** Son Luong Ngoc](https://github.com/sluongng)
 - [**@tagae** Sebastián González](https://github.com/tagae)
+- [**@wyhasany** Michał Rowicki](https://github.com/wyhasany)
 
 Supporters
 --------

--- a/src/main/resources/messages/lombokBundle.properties
+++ b/src/main/resources/messages/lombokBundle.properties
@@ -8,9 +8,7 @@ config.warn.dependency.missing.message=<br>\
 
 config.warn.annotation-processing.disabled.title=Lombok Requires Annotation Processing
 config.warn.annotation-processing.disabled.message=<br>\
-  Annotation processing seems to be disabled for the project "{0}". But lombok is on classpath.<br>\
-  For the lombok plugin to function correctly, please enable it under<br>\
-  <a href="#">"Settings > Build > Compiler > Annotation Processors"</a><br>
+  Do you want to enable annotation processors? <a href="enable">Enable</a><br>
 
 config.warn.dependency.outdated.title=Lombok Dependency is possibly outdated
 config.warn.dependency.outdated.message=<br>\
@@ -22,7 +20,7 @@ daemon.donate.title=Lombok support plugin updated to v{0}
 daemon.donate.content=<br/>\
 Helpful? <b><a href="https://www.paypal.me/mplushnikov">Donate with PayPal</a></b><br/><br/>\
 Fixes:<br/>\
-- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/680">#680</a>): Add support for lombok.builder.className config property, thanks to @tagae (Sebasti·n Gonz·lez)<br>\
+- Fixed (<a href="https://github.com/mplushnikov/lombok-intellij-plugin/issues/680">#680</a>): Add support for lombok.builder.className config property, thanks to @tagae (Sebasti√°n Gonz√°lez)<br>\
   <br>\
   If you find my plugin helpful, donate me using <br><b>\
   <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick\\&hosted_button_id=3F9HXD7A2SMCN\\&source=url">PayPal</a>\


### PR DESCRIPTION
With newest versions of intellij the pop up informing that annotation
processor is disabled won't work. Hence I've fixed checking if
proper checkbox has been marked. Moreover current use experience was
bad as user had to expand notification memoize instruction then
config window has appeared (while instruction disappears) so user has
been in stuck. To resolve that I'm showing more laconic notification
which enables Annotation Processor for user automatically.

tldr;
Before:

![Selection_117](https://user-images.githubusercontent.com/317662/75109400-cd368300-5622-11ea-984c-653295d94aac.png)

then

![Selection_115](https://user-images.githubusercontent.com/317662/75109403-e2131680-5622-11ea-9784-67e8e3bcfbb8.png)

then no one knows what to do here:

![Selection_118](https://user-images.githubusercontent.com/317662/75109416-ff47e500-5622-11ea-833b-072e31458896.png)

After:
![Selection_116](https://user-images.githubusercontent.com/317662/75109408-ed664200-5622-11ea-83ed-383031949e14.png)

then nice balloon informs us that everything has been made for us:

![Selection_119](https://user-images.githubusercontent.com/317662/75109431-46ce7100-5623-11ea-8566-eb6e6b7ba005.png)


