### PR TITLE
Inspections on redundant field modifiers in @Value class

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/inspection/RedundantModifiersOnValueLombokAnnotationInspection.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/inspection/RedundantModifiersOnValueLombokAnnotationInspection.java
@@ -1,0 +1,97 @@
+package de.plushnikov.intellij.plugin.inspection;
+
+import com.intellij.codeInsight.daemon.GroupNames;
+import com.intellij.codeInspection.AbstractBaseJavaLocalInspectionTool;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.*;
+import com.siyeh.ig.fixes.RemoveModifierFix;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static com.intellij.psi.PsiModifier.FINAL;
+import static com.intellij.psi.PsiModifier.PRIVATE;
+
+/**
+ * @author Rowicki Michał
+ */
+public class RedundantModifiersOnValueLombokAnnotationInspection extends AbstractBaseJavaLocalInspectionTool {
+
+  @NotNull
+  @Override
+  public String getGroupDisplayName() {
+    return GroupNames.BUGS_GROUP_NAME;
+  }
+
+  @NotNull
+  @Override
+  public String getDisplayName() {
+    return "Redundant modifiers on @Value lombok annotations inspection";
+  }
+
+  @NotNull
+  @Override
+  public String getShortName() {
+    return "RedundantModifiersValueLombok";
+  }
+
+  @Override
+  public boolean isEnabledByDefault() {
+    return true;
+  }
+
+  @NotNull
+  @Override
+  public PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, final boolean isOnTheFly) {
+    return new LombokElementVisitor(holder);
+  }
+
+  private static class LombokElementVisitor extends JavaElementVisitor {
+
+    private final ProblemsHolder holder;
+
+    LombokElementVisitor(ProblemsHolder holder) {
+      this.holder = holder;
+    }
+
+    @Override
+    public void visitField(PsiField field) {
+      super.visitField(field);
+
+      final PsiElement parent = field.getParent();
+      if (parent instanceof PsiClass) {
+        final PsiClass clazz = (PsiClass) parent;
+        if (clazz.hasAnnotation(lombok.Value.class.getName())) {
+          final PsiModifierList modifierList = field.getModifierList();
+          if (modifierList != null) {
+            if (modifierList.hasExplicitModifier(PRIVATE)) {
+              final Optional<PsiElement> psiPrivate = Arrays.stream(modifierList.getChildren())
+                .filter(psiElement -> PRIVATE.equals(psiElement.getText()))
+                .findFirst();
+
+              psiPrivate.ifPresent(psiElement -> holder.registerProblem(psiElement,
+                "Redundant private field modifier",
+                ProblemHighlightType.WARNING,
+                new RemoveModifierFix(PRIVATE))
+              );
+            }
+            if (modifierList.hasExplicitModifier(FINAL)) {
+              final Optional<PsiElement> psiFinal = Arrays.stream(modifierList.getChildren())
+                .filter(psiElement -> FINAL.equals(psiElement.getText()))
+                .findFirst();
+
+              psiFinal.ifPresent(psiElement -> holder.registerProblem(psiElement,
+                "Redundant final field modifier",
+                ProblemHighlightType.WARNING,
+                new RemoveModifierFix(FINAL))
+              );
+            }
+          }
+        }
+      }
+    }
+
+  }
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/provider/LombokInspectionProvider.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/provider/LombokInspectionProvider.java
@@ -3,6 +3,7 @@ package de.plushnikov.intellij.plugin.provider;
 import com.intellij.codeInspection.InspectionToolProvider;
 import de.plushnikov.intellij.plugin.inspection.DeprecatedLombokAnnotationInspection;
 import de.plushnikov.intellij.plugin.inspection.LombokInspection;
+import de.plushnikov.intellij.plugin.inspection.RedundantModifiersOnValueLombokAnnotationInspection;
 import org.jetbrains.annotations.NotNull;
 
 public class LombokInspectionProvider implements InspectionToolProvider {
@@ -10,6 +11,7 @@ public class LombokInspectionProvider implements InspectionToolProvider {
   @NotNull
   @Override
   public Class[] getInspectionClasses() {
-    return new Class[]{LombokInspection.class, DeprecatedLombokAnnotationInspection.class};
+    return new Class[]{LombokInspection.class, DeprecatedLombokAnnotationInspection.class,
+      RedundantModifiersOnValueLombokAnnotationInspection.class};
   }
 }

--- a/src/test/java/de/plushnikov/intellij/plugin/inspection/RedundantModifiersOnValueLombokInspectionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/inspection/RedundantModifiersOnValueLombokInspectionTest.java
@@ -1,0 +1,21 @@
+package de.plushnikov.intellij.plugin.inspection;
+
+import com.intellij.codeInspection.InspectionProfileEntry;
+
+public class RedundantModifiersOnValueLombokInspectionTest extends LombokInspectionTest {
+
+  @Override
+  protected String getTestDataPath() {
+    return TEST_DATA_INSPECTION_DIRECTORY + "/redundantModifierInspection";
+  }
+
+  @Override
+  protected InspectionProfileEntry getInspection() {
+    return new RedundantModifiersOnValueLombokAnnotationInspection();
+  }
+
+  public void testValueClass() {
+    doTest();
+  }
+
+}

--- a/src/test/java/de/plushnikov/intellij/plugin/inspection/RedundantModifiersOnValueQuickFixTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/inspection/RedundantModifiersOnValueQuickFixTest.java
@@ -1,0 +1,43 @@
+package de.plushnikov.intellij.plugin.inspection;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl;
+import de.plushnikov.intellij.plugin.AbstractLombokLightCodeInsightTestCase;
+
+import java.util.List;
+
+import static de.plushnikov.intellij.plugin.inspection.LombokInspectionTest.TEST_DATA_INSPECTION_DIRECTORY;
+
+public class RedundantModifiersOnValueQuickFixTest extends AbstractLombokLightCodeInsightTestCase {
+
+  @Override
+  protected String getBasePath() {
+    return TEST_DATA_INSPECTION_DIRECTORY + "/redundantModifierInspection";
+  }
+
+  public void testValueClassWithPrivateField() {
+    myFixture.configureByFile(getBasePath() + '/' + getTestName(false) + ".java");
+
+    final List<IntentionAction> availableActions = getAvailableActions();
+    assertTrue("Redundant private field modifier",
+      availableActions.stream().anyMatch(action -> action.getText().contains("Change access modifier")));
+  }
+
+  public void testValueClassWithFinalField() {
+    myFixture.configureByFile(getBasePath() + '/' + getTestName(false) + ".java");
+
+    final List<IntentionAction> availableActions = getAvailableActions();
+    assertTrue("Redundant final field modifier",
+      availableActions.stream().anyMatch(action -> action.getText().contains("Change access modifier")));
+  }
+
+  protected List<IntentionAction> getAvailableActions() {
+    final Editor editor = getEditor();
+    final PsiFile file = getFile();
+    CodeInsightTestFixtureImpl.instantiateAndRun(file, editor, new int[0], false);
+    return CodeInsightTestFixtureImpl.getAvailableIntentions(editor, file);
+  }
+
+}

--- a/testData/inspection/redundantModifierInspection/ValueClass.java
+++ b/testData/inspection/redundantModifierInspection/ValueClass.java
@@ -1,0 +1,6 @@
+@lombok.Value
+public class ValueClass {
+  String field;
+  <warning descr="Redundant private field modifier">private</warning> String field2;
+  <warning descr="Redundant final field modifier">final</warning> String field3;
+}

--- a/testData/inspection/redundantModifierInspection/ValueClassWithFinalField.java
+++ b/testData/inspection/redundantModifierInspection/ValueClassWithFinalField.java
@@ -1,0 +1,4 @@
+@lombok.Value
+public class ValueClass {
+  <caret>final String field1;
+}

--- a/testData/inspection/redundantModifierInspection/ValueClassWithPrivateField.java
+++ b/testData/inspection/redundantModifierInspection/ValueClassWithPrivateField.java
@@ -1,0 +1,4 @@
+@lombok.Value
+public class ValueClass {
+  <caret>private String field1;
+}


### PR DESCRIPTION
It would be nice to inform users that private and final modifiers
on fields are redundant in classes marked with @Value.

![Lombok Inspections(1)](https://user-images.githubusercontent.com/317662/75587530-f4ec7780-5a76-11ea-8e1d-0ed62f6c417a.gif)

// Tests has been added