### PR TITLE
Add intention actions to replace an explicit type with val / var or vice versa

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/inspection/DeprecatedLombokAnnotationInspection.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/inspection/DeprecatedLombokAnnotationInspection.java
@@ -4,10 +4,7 @@ import com.intellij.codeInsight.intention.AddAnnotationFix;
 import com.intellij.codeInspection.AbstractBaseJavaLocalInspectionTool;
 import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
-import com.intellij.psi.JavaElementVisitor;
-import com.intellij.psi.PsiAnnotation;
-import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiModifierListOwner;
+import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/de/plushnikov/intellij/plugin/inspection/modifiers/RedundantModifiersInfo.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/inspection/modifiers/RedundantModifiersInfo.java
@@ -1,6 +1,7 @@
 package de.plushnikov.intellij.plugin.inspection.modifiers;
 
 import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiModifierListOwner;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,7 +36,11 @@ public class RedundantModifiersInfo {
     return dontRunOnModifier;
   }
 
-  public RedundantModifiersInfoType getRedundantModifiersInfoType() {
+  public RedundantModifiersInfoType getType() {
     return redundantModifiersInfoType;
+  }
+
+  public boolean shouldCheck(PsiModifierListOwner psiModifierListOwner) {
+    return true;
   }
 }

--- a/src/main/java/de/plushnikov/intellij/plugin/inspection/modifiers/RedundantModifiersInfoType.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/inspection/modifiers/RedundantModifiersInfoType.java
@@ -7,6 +7,7 @@ public enum RedundantModifiersInfoType {
   CLASS(PsiClass.class),
   FIELD(PsiField.class),
   METHOD(PsiMethod.class),
+  VARIABLE(PsiVariable.class),
   INNER_CLASS(PsiClass.class);
 
   private final Class<? extends PsiModifierListOwner> supportedClass;

--- a/src/main/java/de/plushnikov/intellij/plugin/inspection/modifiers/RedundantModifiersOnValLombokAnnotationInspection.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/inspection/modifiers/RedundantModifiersOnValLombokAnnotationInspection.java
@@ -1,0 +1,21 @@
+package de.plushnikov.intellij.plugin.inspection.modifiers;
+
+import com.intellij.psi.PsiModifierListOwner;
+import com.intellij.psi.PsiVariable;
+import de.plushnikov.intellij.plugin.processor.ValProcessor;
+
+import static com.intellij.psi.PsiModifier.FINAL;
+import static de.plushnikov.intellij.plugin.inspection.modifiers.RedundantModifiersInfoType.VARIABLE;
+
+public class RedundantModifiersOnValLombokAnnotationInspection extends LombokRedundantModifierInspection {
+
+  public RedundantModifiersOnValLombokAnnotationInspection() {
+    super(null, new RedundantModifiersInfo(VARIABLE, null, "'val' already marks variables final.", FINAL) {
+      @Override
+      public boolean shouldCheck(PsiModifierListOwner psiModifierListOwner) {
+        PsiVariable psiVariable = (PsiVariable) psiModifierListOwner;
+        return ValProcessor.isVal(psiVariable);
+      }
+    });
+  }
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/intention/AbstractLombokIntentionAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/intention/AbstractLombokIntentionAction.java
@@ -1,0 +1,16 @@
+package de.plushnikov.intellij.plugin.intention;
+
+import com.intellij.codeInsight.intention.PsiElementBaseIntentionAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import de.plushnikov.intellij.plugin.settings.ProjectSettings;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractLombokIntentionAction extends PsiElementBaseIntentionAction {
+
+  @Override
+  public boolean isAvailable(@NotNull Project project, Editor editor, @NotNull PsiElement element) {
+    return ProjectSettings.isLombokEnabledInProject(project);
+  }
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/AbstractValVarIntentionAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/AbstractValVarIntentionAction.java
@@ -1,0 +1,59 @@
+package de.plushnikov.intellij.plugin.intention.valvar;
+
+import com.intellij.codeInsight.intention.LowPriorityAction;
+import com.intellij.lang.java.JavaLanguage;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import de.plushnikov.intellij.plugin.intention.AbstractLombokIntentionAction;
+import de.plushnikov.intellij.plugin.settings.ProjectSettings;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractValVarIntentionAction extends AbstractLombokIntentionAction implements LowPriorityAction {
+
+  @Override
+  public boolean isAvailable(@NotNull Project project, Editor editor, @NotNull PsiElement element) {
+    if (!super.isAvailable(project, editor, element)) {
+      return false;
+    }
+    if (!ProjectSettings.isEnabled(project, ProjectSettings.IS_VAL_ENABLED)) {
+      return false;
+    }
+    if (element instanceof PsiCompiledElement || !canModify(element) || !element.getLanguage().is(JavaLanguage.INSTANCE)) {
+      return false;
+    }
+
+    setText(getFamilyName());
+
+    PsiParameter parameter = PsiTreeUtil.getParentOfType(element, PsiParameter.class, false, PsiClass.class, PsiCodeBlock.class);
+    if (parameter != null) {
+      return isAvailableOnVariable(parameter);
+    }
+    PsiDeclarationStatement context = PsiTreeUtil.getParentOfType(element, PsiDeclarationStatement.class, false, PsiClass.class, PsiCodeBlock.class);
+    return context != null && isAvailableOnDeclarationStatement(context);
+  }
+
+  @Override
+  public void invoke(@NotNull Project project, Editor editor, @NotNull PsiElement element) {
+    final PsiDeclarationStatement declarationStatement = PsiTreeUtil.getParentOfType(element, PsiDeclarationStatement.class);
+
+    if (declarationStatement != null) {
+      invokeOnDeclarationStatement(declarationStatement);
+      return;
+    }
+
+    final PsiParameter parameter = PsiTreeUtil.getParentOfType(element, PsiParameter.class);
+    if (parameter != null) {
+      invokeOnVariable(parameter);
+    }
+  }
+
+  public abstract boolean isAvailableOnVariable(PsiVariable psiVariable);
+
+  public abstract boolean isAvailableOnDeclarationStatement(PsiDeclarationStatement psiDeclarationStatement);
+
+  public abstract void invokeOnVariable(PsiVariable psiVariable);
+
+  public abstract void invokeOnDeclarationStatement(PsiDeclarationStatement psiDeclarationStatement);
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/from/AbstractReplaceVariableWithExplicitTypeIntentionAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/from/AbstractReplaceVariableWithExplicitTypeIntentionAction.java
@@ -1,0 +1,73 @@
+package de.plushnikov.intellij.plugin.intention.valvar.from;
+
+import com.intellij.codeInspection.RemoveRedundantTypeArgumentsUtil;
+import com.intellij.psi.*;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+import com.intellij.psi.util.PsiTypesUtil;
+import de.plushnikov.intellij.plugin.intention.valvar.AbstractValVarIntentionAction;
+import de.plushnikov.intellij.plugin.processor.ValProcessor;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractReplaceVariableWithExplicitTypeIntentionAction extends AbstractValVarIntentionAction {
+
+  private final Class<?> variableClass;
+
+  public AbstractReplaceVariableWithExplicitTypeIntentionAction(Class<?> variableClass) {
+    this.variableClass = variableClass;
+  }
+
+  @Nls(capitalization = Nls.Capitalization.Sentence)
+  @NotNull
+  @Override
+  public String getFamilyName() {
+    return "Replace '" + variableClass.getSimpleName() + "' with explicit type (Lombok)";
+  }
+
+  @Override
+  public boolean isAvailableOnVariable(PsiVariable psiVariable) {
+    if (variableClass == lombok.val.class) {
+      return ValProcessor.isVal(psiVariable);
+    }
+    if (variableClass == lombok.var.class) {
+      return ValProcessor.isVar(psiVariable);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean isAvailableOnDeclarationStatement(PsiDeclarationStatement context) {
+    if (context.getDeclaredElements().length <= 0) {
+      return false;
+    }
+    PsiElement declaredElement = context.getDeclaredElements()[0];
+    if (!(declaredElement instanceof PsiLocalVariable)) {
+      return false;
+    }
+    return isAvailableOnVariable((PsiLocalVariable) declaredElement);
+  }
+
+  @Override
+  public void invokeOnDeclarationStatement(PsiDeclarationStatement declarationStatement) {
+    if (declarationStatement.getDeclaredElements().length > 0) {
+      PsiElement declaredElement = declarationStatement.getDeclaredElements()[0];
+      if (declaredElement instanceof PsiLocalVariable) {
+        invokeOnVariable((PsiLocalVariable) declaredElement);
+      }
+    }
+  }
+
+  @Override
+  public void invokeOnVariable(PsiVariable psiVariable) {
+    PsiTypeElement psiTypeElement = psiVariable.getTypeElement();
+    if (psiTypeElement == null) {
+      return;
+    }
+    PsiTypesUtil.replaceWithExplicitType(psiTypeElement);
+    RemoveRedundantTypeArgumentsUtil.removeRedundantTypeArguments(psiVariable);
+    executeAfterReplacing(psiVariable);
+    CodeStyleManager.getInstance(psiVariable.getProject()).reformat(psiVariable);
+  }
+
+  protected abstract void executeAfterReplacing(PsiVariable psiVariable);
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/from/ReplaceValWithExplicitTypeIntentionAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/from/ReplaceValWithExplicitTypeIntentionAction.java
@@ -1,0 +1,20 @@
+package de.plushnikov.intellij.plugin.intention.valvar.from;
+
+import com.intellij.psi.PsiModifier;
+import com.intellij.psi.PsiModifierList;
+import com.intellij.psi.PsiVariable;
+
+public class ReplaceValWithExplicitTypeIntentionAction extends AbstractReplaceVariableWithExplicitTypeIntentionAction {
+
+  public ReplaceValWithExplicitTypeIntentionAction() {
+    super(lombok.val.class);
+  }
+
+  @Override
+  protected void executeAfterReplacing(PsiVariable psiVariable) {
+    PsiModifierList psiModifierList = psiVariable.getModifierList();
+    if (psiModifierList != null) {
+      psiModifierList.setModifierProperty(PsiModifier.FINAL, true);
+    }
+  }
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/from/ReplaceVarWithExplicitTypeIntentionAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/from/ReplaceVarWithExplicitTypeIntentionAction.java
@@ -1,0 +1,15 @@
+package de.plushnikov.intellij.plugin.intention.valvar.from;
+
+import com.intellij.psi.PsiVariable;
+
+public class ReplaceVarWithExplicitTypeIntentionAction extends AbstractReplaceVariableWithExplicitTypeIntentionAction {
+
+  public ReplaceVarWithExplicitTypeIntentionAction() {
+    super(lombok.var.class);
+  }
+
+  @Override
+  protected void executeAfterReplacing(PsiVariable psiVariable) {
+
+  }
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/to/AbstractReplaceExplicitTypeWithVariableIntentionAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/to/AbstractReplaceExplicitTypeWithVariableIntentionAction.java
@@ -1,0 +1,85 @@
+package de.plushnikov.intellij.plugin.intention.valvar.to;
+
+import com.intellij.codeInspection.RemoveRedundantTypeArgumentsUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.*;
+import com.intellij.psi.codeStyle.CodeStyleManager;
+import com.intellij.refactoring.introduceVariable.IntroduceVariableBase;
+import de.plushnikov.intellij.plugin.intention.valvar.AbstractValVarIntentionAction;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractReplaceExplicitTypeWithVariableIntentionAction extends AbstractValVarIntentionAction {
+
+  private final Class<?> variableClass;
+
+  public AbstractReplaceExplicitTypeWithVariableIntentionAction(Class<?> variableClass) {
+    this.variableClass = variableClass;
+  }
+
+  @Nls(capitalization = Nls.Capitalization.Sentence)
+  @NotNull
+  @Override
+  public String getFamilyName() {
+    return "Replace explicit type with '" + variableClass.getSimpleName() + "' (Lombok)";
+  }
+
+  @Override
+  public boolean isAvailableOnDeclarationStatement(PsiDeclarationStatement context) {
+    PsiElement[] declaredElements = context.getDeclaredElements();
+    if (declaredElements.length > 1) {
+      return false;
+    }
+    PsiElement declaredElement = declaredElements[0];
+    if (!(declaredElement instanceof PsiLocalVariable)) {
+      return false;
+    }
+    PsiLocalVariable localVariable = (PsiLocalVariable) declaredElement;
+    if (!localVariable.hasInitializer()) {
+      return false;
+    }
+    PsiExpression initializer = localVariable.getInitializer();
+    if (initializer instanceof PsiArrayInitializerExpression || initializer instanceof PsiLambdaExpression) {
+      return false;
+    }
+    if (localVariable.getTypeElement().isInferredType()) {
+      return false;
+    }
+    return isAvailableOnDeclarationCustom(context, localVariable);
+  }
+
+  protected abstract boolean isAvailableOnDeclarationCustom(PsiDeclarationStatement context, PsiLocalVariable localVariable);
+
+  @Override
+  public void invokeOnDeclarationStatement(PsiDeclarationStatement declarationStatement) {
+    if (declarationStatement.getDeclaredElements().length == 1) {
+      PsiLocalVariable localVariable = (PsiLocalVariable) declarationStatement.getDeclaredElements()[0];
+      invokeOnVariable(localVariable);
+    }
+  }
+
+  @Override
+  public void invokeOnVariable(PsiVariable psiVariable) {
+    Project project = psiVariable.getProject();
+    psiVariable.normalizeDeclaration();
+    PsiTypeElement typeElement = psiVariable.getTypeElement();
+    if (typeElement == null || typeElement.isInferredType()) {
+      return;
+    }
+
+    PsiElementFactory elementFactory = JavaPsiFacade.getElementFactory(project);
+    PsiClass variablePsiClass = JavaPsiFacade.getInstance(project).findClass(variableClass.getName(), psiVariable.getResolveScope());
+    if (variablePsiClass == null) {
+      return;
+    }
+    PsiJavaCodeReferenceElement referenceElementByFQClassName = elementFactory.createReferenceElementByFQClassName(variableClass.getName(), psiVariable.getResolveScope());
+    typeElement = (PsiTypeElement) IntroduceVariableBase.expandDiamondsAndReplaceExplicitTypeWithVar(typeElement, typeElement);
+    typeElement.deleteChildRange(typeElement.getFirstChild(), typeElement.getLastChild());
+    typeElement.add(referenceElementByFQClassName);
+    RemoveRedundantTypeArgumentsUtil.removeRedundantTypeArguments(psiVariable);
+    executeAfterReplacing(psiVariable);
+    CodeStyleManager.getInstance(project).reformat(psiVariable);
+  }
+
+  protected abstract void executeAfterReplacing(PsiVariable psiVariable);
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/to/ReplaceExplicitTypeWithValIntentionAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/to/ReplaceExplicitTypeWithValIntentionAction.java
@@ -1,0 +1,38 @@
+package de.plushnikov.intellij.plugin.intention.valvar.to;
+
+import com.intellij.psi.*;
+
+import static com.intellij.psi.PsiModifier.*;
+
+public class ReplaceExplicitTypeWithValIntentionAction extends AbstractReplaceExplicitTypeWithVariableIntentionAction {
+
+  public ReplaceExplicitTypeWithValIntentionAction() {
+    super(lombok.val.class);
+  }
+
+  @Override
+  protected boolean isAvailableOnDeclarationCustom(PsiDeclarationStatement declarationStatement, PsiLocalVariable localVariable) {
+    return !(declarationStatement.getParent() instanceof PsiForStatement);
+  }
+
+  @Override
+  protected void executeAfterReplacing(PsiVariable psiVariable) {
+    PsiModifierList modifierList = psiVariable.getModifierList();
+    if (modifierList != null) {
+      modifierList.setModifierProperty(FINAL, false);
+    }
+  }
+
+  @Override
+  public boolean isAvailableOnVariable(PsiVariable psiVariable) {
+    if (!(psiVariable instanceof PsiParameter)) {
+      return false;
+    }
+    PsiParameter parameter = (PsiParameter) psiVariable;
+    if (!(parameter.getDeclarationScope() instanceof PsiForeachStatement)) {
+      return false;
+    }
+    PsiTypeElement typeElement = parameter.getTypeElement();
+    return typeElement == null || !typeElement.isInferredType();
+  }
+}

--- a/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/to/ReplaceExplicitTypeWithVarIntentionAction.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/intention/valvar/to/ReplaceExplicitTypeWithVarIntentionAction.java
@@ -1,0 +1,41 @@
+package de.plushnikov.intellij.plugin.intention.valvar.to;
+
+import com.intellij.psi.*;
+import org.jetbrains.annotations.NotNull;
+
+import static com.intellij.psi.PsiModifier.*;
+
+public class ReplaceExplicitTypeWithVarIntentionAction extends AbstractReplaceExplicitTypeWithVariableIntentionAction {
+
+  public ReplaceExplicitTypeWithVarIntentionAction() {
+    super(lombok.var.class);
+  }
+
+  @Override
+  protected boolean isAvailableOnDeclarationCustom(PsiDeclarationStatement declarationStatement, PsiLocalVariable localVariable) {
+    return isNotFinal(localVariable);
+  }
+
+  @Override
+  protected void executeAfterReplacing(PsiVariable psiVariable) {
+  }
+
+  @Override
+  public boolean isAvailableOnVariable(@NotNull PsiVariable psiVariable) {
+    if (!(psiVariable instanceof PsiParameter)) {
+      return false;
+    }
+    PsiParameter psiParameter = (PsiParameter) psiVariable;
+    PsiElement declarationScope = psiParameter.getDeclarationScope();
+    if (!(declarationScope instanceof PsiForStatement) && !(declarationScope instanceof PsiForeachStatement)) {
+      return false;
+    }
+    PsiTypeElement typeElement = psiParameter.getTypeElement();
+    return typeElement != null && !typeElement.isInferredType() && isNotFinal(psiParameter);
+  }
+
+  private boolean isNotFinal(@NotNull PsiVariable variable) {
+    PsiModifierList modifierList = variable.getModifierList();
+    return modifierList == null || !modifierList.hasExplicitModifier(FINAL);
+  }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -190,6 +190,31 @@
       enabledByDefault="true"
       implementationClass="de.plushnikov.intellij.plugin.inspection.modifiers.RedundantModifiersOnUtilityClassLombokAnnotationInspection"/>
 
+    <localInspection
+      displayName="Unnecessary final before 'val'"
+      groupPath="Lombok"
+      groupName="Redundant modifiers"
+      shortName="RedundantModifiersValLombok"
+      enabledByDefault="true"
+      implementationClass="de.plushnikov.intellij.plugin.inspection.modifiers.RedundantModifiersOnValLombokAnnotationInspection"/>
+
+    <intentionAction>
+      <className>de.plushnikov.intellij.plugin.intention.valvar.to.ReplaceExplicitTypeWithValIntentionAction</className>
+      <category>Lombok</category>
+    </intentionAction>
+    <intentionAction>
+      <className>de.plushnikov.intellij.plugin.intention.valvar.to.ReplaceExplicitTypeWithVarIntentionAction</className>
+      <category>Lombok</category>
+    </intentionAction>
+    <intentionAction>
+      <className>de.plushnikov.intellij.plugin.intention.valvar.from.ReplaceValWithExplicitTypeIntentionAction</className>
+      <category>Lombok</category>
+    </intentionAction>
+    <intentionAction>
+      <className>de.plushnikov.intellij.plugin.intention.valvar.from.ReplaceVarWithExplicitTypeIntentionAction</className>
+      <category>Lombok</category>
+    </intentionAction>
+
     <codeInsight.template.postfixTemplateProvider language="JAVA"
                                                   implementationClass="de.plushnikov.intellij.plugin.extension.postfix.LombokPostfixTemplateProvider"/>
   </extensions>

--- a/src/main/resources/inspectionDescriptions/DeprecatedLombok.html
+++ b/src/main/resources/inspectionDescriptions/DeprecatedLombok.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Inspection for deprecated Lombok annotations which are not supported anymore and which should be replaced by ones promoted to the main package.
+Finds deprecated Lombok annotations which are not supported anymore and offers quick fixes to replace them with ones promoted to the main package.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/Lombok.html
+++ b/src/main/resources/inspectionDescriptions/Lombok.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Inspection for Lombok annotations.
+Offers general inspections for Lombok annotations.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RedundantModifiersUtilityClassLombok.html
+++ b/src/main/resources/inspectionDescriptions/RedundantModifiersUtilityClassLombok.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Inspection for Lombok @UtilityClass annotation and redundant modifiers.
+Reports unneeded modifiers for classes annotated with @UtilityClass.
 </body>
 </html>

--- a/src/main/resources/inspectionDescriptions/RedundantModifiersValLombok.html
+++ b/src/main/resources/inspectionDescriptions/RedundantModifiersValLombok.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Reports unneeded final modifier before 'val'.
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/RedundantModifiersValueLombok.html
+++ b/src/main/resources/inspectionDescriptions/RedundantModifiersValueLombok.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-Inspection for Lombok @Value annotation and redundant modifiers.
+Reports unneeded modifiers for classes annotated with @Value.
 </body>
 </html>

--- a/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithValIntentionAction/after.java.template
+++ b/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithValIntentionAction/after.java.template
@@ -1,0 +1,5 @@
+public class X {
+  void f() {
+    val FIVE = 5;
+  }
+}

--- a/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithValIntentionAction/before.java.template
+++ b/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithValIntentionAction/before.java.template
@@ -1,0 +1,5 @@
+public class X {
+  void f() {
+    <spot>final int FIVE = 5</spot>;
+  }
+}

--- a/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithValIntentionAction/description.html
+++ b/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithValIntentionAction/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects declaration statements with explicit types that can use 'val' instead.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithVarIntentionAction/after.java.template
+++ b/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithVarIntentionAction/after.java.template
@@ -1,0 +1,6 @@
+public class X {
+  void a() {
+    var a = 2;
+    a++;
+  }
+}

--- a/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithVarIntentionAction/before.java.template
+++ b/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithVarIntentionAction/before.java.template
@@ -1,0 +1,6 @@
+public class X {
+  void a() {
+    <spot>int a = 2</spot>;
+    a++;
+  }
+}

--- a/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithVarIntentionAction/description.html
+++ b/src/main/resources/intentionDescriptions/ReplaceExplicitTypeWithVarIntentionAction/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects declaration statements with explicit types that can use 'var' instead.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/ReplaceValWithExplicitTypeIntentionAction/after.java.template
+++ b/src/main/resources/intentionDescriptions/ReplaceValWithExplicitTypeIntentionAction/after.java.template
@@ -1,0 +1,5 @@
+public class X {
+  void a() {
+    final ArrayList<String> arrayList = new ArrayList<>();
+  }
+}

--- a/src/main/resources/intentionDescriptions/ReplaceValWithExplicitTypeIntentionAction/before.java.template
+++ b/src/main/resources/intentionDescriptions/ReplaceValWithExplicitTypeIntentionAction/before.java.template
@@ -1,0 +1,5 @@
+public class X {
+  void a() {
+    <spot>val arrayList = new ArrayList<String>()</spot>;
+  }
+}

--- a/src/main/resources/intentionDescriptions/ReplaceValWithExplicitTypeIntentionAction/description.html
+++ b/src/main/resources/intentionDescriptions/ReplaceValWithExplicitTypeIntentionAction/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects declaration statements with 'val' that can use the explicit type instead.
+</body>
+</html>

--- a/src/main/resources/intentionDescriptions/ReplaceVarWithExplicitTypeIntentionAction/after.java.template
+++ b/src/main/resources/intentionDescriptions/ReplaceVarWithExplicitTypeIntentionAction/after.java.template
@@ -1,0 +1,5 @@
+public class X {
+  void a() {
+    ArrayList<String> arrayList = new ArrayList<>();
+  }
+}

--- a/src/main/resources/intentionDescriptions/ReplaceVarWithExplicitTypeIntentionAction/before.java.template
+++ b/src/main/resources/intentionDescriptions/ReplaceVarWithExplicitTypeIntentionAction/before.java.template
@@ -1,0 +1,5 @@
+public class X {
+  void a() {
+    <spot>var arrayList = new ArrayList<String>()</spot>;
+  }
+}

--- a/src/main/resources/intentionDescriptions/ReplaceVarWithExplicitTypeIntentionAction/description.html
+++ b/src/main/resources/intentionDescriptions/ReplaceVarWithExplicitTypeIntentionAction/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Detects declaration statements with 'var' that can use the explicit type instead.
+</body>
+</html>

--- a/src/test/java/de/plushnikov/intellij/plugin/inspection/RedundantModifiersOnValLombokInspectionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/inspection/RedundantModifiersOnValLombokInspectionTest.java
@@ -1,0 +1,31 @@
+package de.plushnikov.intellij.plugin.inspection;
+
+import com.intellij.codeInspection.InspectionProfileEntry;
+import com.intellij.openapi.util.RecursionManager;
+import de.plushnikov.intellij.plugin.inspection.modifiers.RedundantModifiersOnValLombokAnnotationInspection;
+
+public class RedundantModifiersOnValLombokInspectionTest extends LombokInspectionTest {
+
+  @Override
+  protected String getTestDataPath() {
+    return TEST_DATA_INSPECTION_DIRECTORY + "/redundantModifierInspection";
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    //TODO disable assertions for the moment
+    RecursionManager.disableMissedCacheAssertions(myFixture.getProjectDisposable());
+  }
+
+  @Override
+  protected InspectionProfileEntry getInspection() {
+    return new RedundantModifiersOnValLombokAnnotationInspection();
+  }
+
+  public void testValClass() {
+    doTest();
+  }
+
+}

--- a/src/test/java/de/plushnikov/intellij/plugin/intention/LombokIntentionActionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/intention/LombokIntentionActionTest.java
@@ -1,0 +1,40 @@
+package de.plushnikov.intellij.plugin.intention;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.openapi.util.RecursionManager;
+import com.intellij.psi.PsiFile;
+import de.plushnikov.intellij.plugin.AbstractLombokLightCodeInsightTestCase;
+
+public abstract class LombokIntentionActionTest extends AbstractLombokLightCodeInsightTestCase {
+
+  public static final String TEST_DATA_INTENTION_DIRECTORY = "testData/intention";
+
+  @Override
+  protected String getBasePath() {
+    return TEST_DATA_INTENTION_DIRECTORY;
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    //TODO disable assertions for the moment
+    RecursionManager.disableMissedCacheAssertions(myFixture.getProjectDisposable());
+  }
+
+  public abstract IntentionAction getIntentionAction();
+
+  public abstract boolean wasInvocationSuccessful();
+
+  public void doTest() {
+    PsiFile psiFile = loadToPsiFile(getTestName(false) + ".java");
+    IntentionAction intentionAction = getIntentionAction();
+    assertTrue("Intention \"" + intentionAction.getFamilyName() + "\" was not found in file",
+      myFixture.getAvailableIntentions().stream().anyMatch(action -> action.getFamilyName().equals(intentionAction.getFamilyName())));
+    assertTrue("Intention \"" + intentionAction.getFamilyName() + "\" was not available at caret",
+      intentionAction.isAvailable(myFixture.getProject(), myFixture.getEditor(), psiFile));
+    myFixture.launchAction(intentionAction);
+    assertTrue("Intention \"" + intentionAction.getFamilyName() + "\" was not properly invoked",
+      wasInvocationSuccessful());
+  }
+}

--- a/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/from/ReplaceValWithExplicitTypeGenericsIntentionActionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/from/ReplaceValWithExplicitTypeGenericsIntentionActionTest.java
@@ -1,0 +1,41 @@
+package de.plushnikov.intellij.plugin.intention.valvar.from;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import de.plushnikov.intellij.plugin.intention.LombokIntentionActionTest;
+
+import static com.intellij.psi.PsiModifier.FINAL;
+
+public class ReplaceValWithExplicitTypeGenericsIntentionActionTest extends LombokIntentionActionTest {
+
+  public static final String REPLACE_VAL_VAR_WITH_EXPLICIT_TYPE_DIRECTORY  = TEST_DATA_INTENTION_DIRECTORY + "/valvar/replaceValVar";
+
+  @Override
+  protected String getBasePath() {
+    return REPLACE_VAL_VAR_WITH_EXPLICIT_TYPE_DIRECTORY;
+  }
+
+  @Override
+  public IntentionAction getIntentionAction() {
+    return new ReplaceValWithExplicitTypeIntentionAction();
+  }
+
+  @Override
+  public boolean wasInvocationSuccessful() {
+    PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+    PsiLocalVariable localVariable = PsiTreeUtil.getParentOfType(elementAtCaret, PsiLocalVariable.class);
+    if (localVariable == null) {
+      return false;
+    }
+    PsiModifierList modifierList = localVariable.getModifierList();
+    PsiTypeElement typeElement = localVariable.getTypeElement();
+    return typeElement.getText().equals("ArrayList<String>")
+      && modifierList != null
+      && modifierList.hasExplicitModifier(FINAL);
+  }
+
+  public void testReplaceValWithGenerics() {
+    doTest();
+  }
+}

--- a/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/from/ReplaceValWithExplicitTypeIntentionActionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/from/ReplaceValWithExplicitTypeIntentionActionTest.java
@@ -1,0 +1,43 @@
+package de.plushnikov.intellij.plugin.intention.valvar.from;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLocalVariable;
+import com.intellij.psi.PsiModifierList;
+import com.intellij.psi.PsiTypeElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import de.plushnikov.intellij.plugin.intention.LombokIntentionActionTest;
+
+import static com.intellij.psi.PsiModifier.FINAL;
+import static de.plushnikov.intellij.plugin.intention.valvar.from.ReplaceValWithExplicitTypeGenericsIntentionActionTest.REPLACE_VAL_VAR_WITH_EXPLICIT_TYPE_DIRECTORY;
+
+public class ReplaceValWithExplicitTypeIntentionActionTest extends LombokIntentionActionTest {
+
+  @Override
+  protected String getBasePath() {
+    return REPLACE_VAL_VAR_WITH_EXPLICIT_TYPE_DIRECTORY;
+  }
+
+  @Override
+  public IntentionAction getIntentionAction() {
+    return new ReplaceValWithExplicitTypeIntentionAction();
+  }
+
+  @Override
+  public boolean wasInvocationSuccessful() {
+    PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+    PsiLocalVariable localVariable = PsiTreeUtil.getParentOfType(elementAtCaret, PsiLocalVariable.class);
+    if (localVariable == null) {
+      return false;
+    }
+    PsiModifierList modifierList = localVariable.getModifierList();
+    PsiTypeElement typeElement = localVariable.getTypeElement();
+    return typeElement.getText().equals("String")
+      && modifierList != null
+      && modifierList.hasExplicitModifier(FINAL);
+  }
+
+  public void testReplaceVal() {
+    doTest();
+  }
+}

--- a/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/from/ReplaceVarWithExplicitTypeIntentionActionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/from/ReplaceVarWithExplicitTypeIntentionActionTest.java
@@ -1,0 +1,38 @@
+package de.plushnikov.intellij.plugin.intention.valvar.from;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLocalVariable;
+import com.intellij.psi.PsiTypeElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import de.plushnikov.intellij.plugin.intention.LombokIntentionActionTest;
+
+import static de.plushnikov.intellij.plugin.intention.valvar.from.ReplaceValWithExplicitTypeGenericsIntentionActionTest.REPLACE_VAL_VAR_WITH_EXPLICIT_TYPE_DIRECTORY;
+
+public class ReplaceVarWithExplicitTypeIntentionActionTest extends LombokIntentionActionTest {
+
+  @Override
+  protected String getBasePath() {
+    return REPLACE_VAL_VAR_WITH_EXPLICIT_TYPE_DIRECTORY;
+  }
+
+  @Override
+  public IntentionAction getIntentionAction() {
+    return new ReplaceVarWithExplicitTypeIntentionAction();
+  }
+
+  @Override
+  public boolean wasInvocationSuccessful() {
+    PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+    PsiLocalVariable localVariable = PsiTreeUtil.getParentOfType(elementAtCaret, PsiLocalVariable.class);
+    if (localVariable == null) {
+      return false;
+    }
+    PsiTypeElement typeElement = localVariable.getTypeElement();
+    return typeElement.getText().equals("String");
+  }
+
+  public void testReplaceVar() {
+    doTest();
+  }
+}

--- a/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/to/ReplaceExplicitTypeWithVarIntentionActionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/to/ReplaceExplicitTypeWithVarIntentionActionTest.java
@@ -1,0 +1,38 @@
+package de.plushnikov.intellij.plugin.intention.valvar.to;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLocalVariable;
+import com.intellij.psi.PsiTypeElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import de.plushnikov.intellij.plugin.intention.LombokIntentionActionTest;
+
+import static de.plushnikov.intellij.plugin.intention.valvar.to.ValAndVarIntentionActionTest.EXPLICIT_TO_VAL_VAR_DIRECTORY;
+
+public class ReplaceExplicitTypeWithVarIntentionActionTest extends LombokIntentionActionTest {
+
+  @Override
+  protected String getBasePath() {
+    return EXPLICIT_TO_VAL_VAR_DIRECTORY;
+  }
+
+  @Override
+  public IntentionAction getIntentionAction() {
+    return new ReplaceExplicitTypeWithVarIntentionAction();
+  }
+
+  @Override
+  public boolean wasInvocationSuccessful() {
+    PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+    PsiLocalVariable localVariable = PsiTreeUtil.getParentOfType(elementAtCaret, PsiLocalVariable.class);
+    if (localVariable == null) {
+      return false;
+    }
+    PsiTypeElement typeElement = localVariable.getTypeElement();
+    return typeElement.getText().equals("var");
+  }
+
+  public void testTypeWithVar() {
+    doTest();
+  }
+}

--- a/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/to/ReplaceFinalExplicitTypeWithValIntentionActionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/to/ReplaceFinalExplicitTypeWithValIntentionActionTest.java
@@ -1,0 +1,41 @@
+package de.plushnikov.intellij.plugin.intention.valvar.to;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiLocalVariable;
+import com.intellij.psi.PsiModifierList;
+import com.intellij.psi.PsiTypeElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import de.plushnikov.intellij.plugin.intention.LombokIntentionActionTest;
+
+import static com.intellij.psi.PsiModifier.FINAL;
+import static de.plushnikov.intellij.plugin.intention.valvar.to.ValAndVarIntentionActionTest.EXPLICIT_TO_VAL_VAR_DIRECTORY;
+
+public class ReplaceFinalExplicitTypeWithValIntentionActionTest extends LombokIntentionActionTest {
+
+  @Override
+  protected String getBasePath() {
+    return EXPLICIT_TO_VAL_VAR_DIRECTORY;
+  }
+
+  @Override
+  public IntentionAction getIntentionAction() {
+    return new ReplaceExplicitTypeWithValIntentionAction();
+  }
+
+  @Override
+  public boolean wasInvocationSuccessful() {
+    PsiElement elementAtCaret = myFixture.getFile().findElementAt(myFixture.getCaretOffset());
+    PsiLocalVariable localVariable = PsiTreeUtil.getParentOfType(elementAtCaret, PsiLocalVariable.class);
+    if (localVariable == null) {
+      return false;
+    }
+    PsiModifierList modifierList = localVariable.getModifierList();
+    PsiTypeElement typeElement = localVariable.getTypeElement();
+    return typeElement.getText().equals("val") && localVariable.hasModifierProperty(FINAL) && modifierList != null && !modifierList.hasExplicitModifier(FINAL);
+  }
+
+  public void testFinalTypeWithVal() {
+    doTest();
+  }
+}

--- a/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/to/ValAndVarIntentionActionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/intention/valvar/to/ValAndVarIntentionActionTest.java
@@ -1,0 +1,36 @@
+package de.plushnikov.intellij.plugin.intention.valvar.to;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import de.plushnikov.intellij.plugin.AbstractLombokLightCodeInsightTestCase;
+
+import static de.plushnikov.intellij.plugin.intention.LombokIntentionActionTest.TEST_DATA_INTENTION_DIRECTORY;
+
+public class ValAndVarIntentionActionTest extends AbstractLombokLightCodeInsightTestCase {
+
+  public static final String EXPLICIT_TO_VAL_VAR_DIRECTORY = TEST_DATA_INTENTION_DIRECTORY + "/valvar/replaceExplicitType";
+
+  @Override
+  protected String getBasePath() {
+    return EXPLICIT_TO_VAL_VAR_DIRECTORY;
+  }
+
+  public void testValAndVar() {
+    loadToPsiFile(getTestName(false) + ".java");
+    IntentionAction replaceExplicitTypeWithValIntentionAction = new ReplaceExplicitTypeWithValIntentionAction();
+    IntentionAction replaceExplicitTypeWithVarIntentionAction = new ReplaceExplicitTypeWithVarIntentionAction();
+    boolean foundVal = false;
+    boolean foundVar = false;
+    for (IntentionAction availableIntention : myFixture.getAvailableIntentions()) {
+      if (availableIntention.getFamilyName().equals(replaceExplicitTypeWithValIntentionAction.getFamilyName())) {
+        foundVal = true;
+      }
+      if (availableIntention.getFamilyName().equals(replaceExplicitTypeWithVarIntentionAction.getFamilyName())) {
+        foundVar = true;
+      }
+      if (foundVal && foundVar) {
+        break;
+      }
+    }
+    assertTrue("Both intention actions should be available", foundVal && foundVar);
+  }
+}

--- a/test-manual/src/main/java/de/plushnikov/val/ValIntersection.java
+++ b/test-manual/src/main/java/de/plushnikov/val/ValIntersection.java
@@ -1,0 +1,13 @@
+package de.plushnikov.val;
+
+import lombok.val;
+
+public class ValIntersection {
+  public static void main(String[] args) {
+    int a = 4;
+    a++;
+    int b = 0b101;
+    val test = a == b ? 5 : "";
+    System.out.println(test.toString());
+  }
+}

--- a/testData/inspection/redundantModifierInspection/ValClass.java
+++ b/testData/inspection/redundantModifierInspection/ValClass.java
@@ -1,0 +1,6 @@
+import lombok.val;
+public class ValClass {
+  public void test() {
+    <warning descr="'val' already marks variables final.">final</warning> val FIVE = 5;
+  }
+}

--- a/testData/intention/valvar/replaceExplicitType/FinalTypeWithVal.java
+++ b/testData/intention/valvar/replaceExplicitType/FinalTypeWithVal.java
@@ -1,0 +1,5 @@
+public class FinalTypeWithVal {
+  public void testMethod() {
+    final String<caret> testVariable = "";
+  }
+}

--- a/testData/intention/valvar/replaceExplicitType/TypeWithVar.java
+++ b/testData/intention/valvar/replaceExplicitType/TypeWithVar.java
@@ -1,0 +1,5 @@
+public class TypeWithVar {
+  public void testMethod() {
+    String<caret> testVariable = "";
+  }
+}

--- a/testData/intention/valvar/replaceExplicitType/ValAndVar.java
+++ b/testData/intention/valvar/replaceExplicitType/ValAndVar.java
@@ -1,0 +1,5 @@
+public class ValAndVar {
+  public void testMethod() {
+    String<caret> testVariable = "";
+  }
+}

--- a/testData/intention/valvar/replaceValVar/ReplaceVal.java
+++ b/testData/intention/valvar/replaceValVar/ReplaceVal.java
@@ -1,0 +1,7 @@
+import lombok.val;
+
+public class TestReplaceVal {
+  public void testReplaceVal() {
+    val<caret> test = "";
+  }
+}

--- a/testData/intention/valvar/replaceValVar/ReplaceValWithGenerics.java
+++ b/testData/intention/valvar/replaceValVar/ReplaceValWithGenerics.java
@@ -1,0 +1,7 @@
+import lombok.val;
+
+public class ReplaceValWithGenerics {
+  public void testMethod() {
+    val<caret> list = new ArrayList<String>();
+  }
+}

--- a/testData/intention/valvar/replaceValVar/ReplaceVar.java
+++ b/testData/intention/valvar/replaceValVar/ReplaceVar.java
@@ -1,0 +1,7 @@
+import lombok.var;
+
+public class ReplaceVar {
+  public void testReplaceVar() {
+    var<caret> test = "";
+  }
+}


### PR DESCRIPTION
- Add redundant modifier detection for 'final val'
- Improve type detection for conditional expressions
- Improve type detection for intersection types. Now takes first conjunct type, just like Lombok itself, instead of one of the two types.
- Add tests for intention actions

This should fix #718, even though they're only intentions, not inspections, but they should be convertable quite easily if you think inspections would be better.

The actions are intentionally placed lower on the list of actions (with LowPriorityAction):
![image](https://user-images.githubusercontent.com/5239767/75989390-79198180-5ef3-11ea-84ed-8e59bf232959.png)

If there's a final on the variable or parameter, only the 'val' action shows up:
![image](https://user-images.githubusercontent.com/5239767/75989529-b7af3c00-5ef3-11ea-9913-342ab3e4e5bb.png)

Selecting it will remove the final and the type and replace it with 'val'.

The same goes for the other way:
![image](https://user-images.githubusercontent.com/5239767/75989581-d01f5680-5ef3-11ea-8708-77944313a9fc.png)

The 'val' action will be replaced with a final and the explicit type when you select it.

As I was creating this pull request, I noticed that I didn't create any tests for val in foreach-loops or var in for/foreach-loops, maybe you can create those if you think they're totally necessary.