### PR TITLE
Do not use ImplicitUsageProvider in GenerateConstructorAction

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/action/generate/LombokGenerateConstructorHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/action/generate/LombokGenerateConstructorHandler.java
@@ -1,16 +1,10 @@
 package de.plushnikov.intellij.plugin.action.generate;
 
-import com.intellij.codeInsight.daemon.ImplicitUsageProvider;
-import com.intellij.codeInsight.generation.ClassMember;
-import com.intellij.codeInsight.generation.GenerateConstructorHandler;
-import com.intellij.codeInsight.generation.GenerationInfo;
-import com.intellij.codeInsight.generation.PsiFieldMember;
-import com.intellij.codeInsight.generation.PsiGenerationInfo;
+import com.intellij.codeInsight.generation.*;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiField;
 import com.intellij.psi.PsiModifier;
 import com.intellij.util.IncorrectOperationException;
-import de.plushnikov.intellij.plugin.provider.LombokImplicitUsageProvider;
 import de.plushnikov.intellij.plugin.psi.LombokLightMethodBuilder;
 import org.jetbrains.annotations.NotNull;
 
@@ -21,13 +15,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class LombokGenerateConstructorHandler extends GenerateConstructorHandler {
-
   @Override
   protected ClassMember[] getAllOriginalMembers(PsiClass aClass) {
     PsiField[] fields = aClass.getFields();
     ArrayList<ClassMember> array = new ArrayList<>();
-    List<ImplicitUsageProvider> implicitUsageProviders = ImplicitUsageProvider.EP_NAME.getExtensionList();
-    fieldLoop:
     for (PsiField field : fields) {
       if (field.hasModifierProperty(PsiModifier.STATIC)) {
         continue;
@@ -37,11 +28,6 @@ public class LombokGenerateConstructorHandler extends GenerateConstructorHandler
         continue;
       }
 
-      for (ImplicitUsageProvider provider : implicitUsageProviders) {
-        if (!(provider instanceof LombokImplicitUsageProvider) && provider.isImplicitWrite(field)) {
-          continue fieldLoop;
-        }
-      }
       array.add(new PsiFieldMember(field));
     }
     return array.toArray(new ClassMember[0]);


### PR DESCRIPTION
Idea team decided not to use ImplicitUsageProvider EP during constructor generation since it makes some class members unavailable to be passed as a constructor parameters. For instance, such problem existed in JPA Entities. Today the new behaviour is present on the Idea side, but the old one still exists in Lombok plugin. In case both JPA plugin and Lombok plugin are installed and enabled, user still can not create constructor with desired fields because Lombok overrides constructor generation rule with the outdated one.

For more info please have a look at the corresponding issue: https://youtrack.jetbrains.com/issue/IDEA-228014

I wish we could merge this PR and fix constructor generation on the both sides :)