### PR TITLE
Consider navigable element in equality - seems to fix psi outdated

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightClassBuilder.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightClassBuilder.java
@@ -1,6 +1,5 @@
 package de.plushnikov.intellij.plugin.psi;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiClassType;
@@ -28,8 +27,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class LombokLightClassBuilder extends LightPsiClassBuilder implements PsiExtensibleClass {
-  private static final Logger LOG = Logger.getInstance(LombokLightClassBuilder.class);
-
   private boolean myIsEnum;
   private final String myQualifiedName;
   private final Icon myBaseIcon;
@@ -203,9 +200,6 @@ public class LombokLightClassBuilder extends LightPsiClassBuilder implements Psi
     LombokLightClassBuilder that = (LombokLightClassBuilder) o;
 
     if(getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
-      if(myQualifiedName.equals(that.myQualifiedName)) {
-        LOG.warn("Usually I would have been equal!");
-      }
       return false;
     }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightClassBuilder.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightClassBuilder.java
@@ -1,5 +1,6 @@
 package de.plushnikov.intellij.plugin.psi;
 
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiClassType;
@@ -27,6 +28,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class LombokLightClassBuilder extends LightPsiClassBuilder implements PsiExtensibleClass {
+  private static final Logger LOG = Logger.getInstance(LombokLightClassBuilder.class);
+
   private boolean myIsEnum;
   private final String myQualifiedName;
   private final Icon myBaseIcon;
@@ -198,6 +201,13 @@ public class LombokLightClassBuilder extends LightPsiClassBuilder implements Psi
     }
 
     LombokLightClassBuilder that = (LombokLightClassBuilder) o;
+
+    if(getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
+      if(myQualifiedName.equals(that.myQualifiedName)) {
+        LOG.warn("Usually I would have been equal!");
+      }
+      return false;
+    }
 
     return myQualifiedName.equals(that.myQualifiedName);
   }

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightFieldBuilder.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightFieldBuilder.java
@@ -1,6 +1,7 @@
 package de.plushnikov.intellij.plugin.psi;
 
 import com.intellij.lang.java.JavaLanguage;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
@@ -23,6 +24,8 @@ import java.util.stream.Stream;
  * @author Plushnikov Michail
  */
 public class LombokLightFieldBuilder extends LightFieldBuilder {
+  private static final Logger LOG = Logger.getInstance(LombokLightFieldBuilder.class);
+
   private String myName;
   private final LombokLightIdentifier myNameIdentifier;
   private final LombokLightModifierList myModifierList;
@@ -141,6 +144,13 @@ public class LombokLightFieldBuilder extends LightFieldBuilder {
 
         stillEquivalent = (null == containingClass && null == anotherContainingClass) ||
           (null != containingClass && containingClass.isEquivalentTo(anotherContainingClass));
+      }
+
+      if(getNavigationElement() != this && !getNavigationElement().equals(anotherLightField.getNavigationElement())) {
+        if(stillEquivalent) {
+          LOG.warn("Usually I would have been equal!");
+        }
+        stillEquivalent = false;
       }
 
       return stillEquivalent;

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightFieldBuilder.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightFieldBuilder.java
@@ -1,7 +1,6 @@
 package de.plushnikov.intellij.plugin.psi;
 
 import com.intellij.lang.java.JavaLanguage;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
@@ -24,8 +23,6 @@ import java.util.stream.Stream;
  * @author Plushnikov Michail
  */
 public class LombokLightFieldBuilder extends LightFieldBuilder {
-  private static final Logger LOG = Logger.getInstance(LombokLightFieldBuilder.class);
-
   private String myName;
   private final LombokLightIdentifier myNameIdentifier;
   private final LombokLightModifierList myModifierList;
@@ -147,9 +144,6 @@ public class LombokLightFieldBuilder extends LightFieldBuilder {
       }
 
       if(getNavigationElement() != this && !getNavigationElement().equals(anotherLightField.getNavigationElement())) {
-        if(stillEquivalent) {
-          LOG.warn("Usually I would have been equal!");
-        }
         stillEquivalent = false;
       }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightIdentifier.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightIdentifier.java
@@ -1,14 +1,19 @@
 package de.plushnikov.intellij.plugin.psi;
 
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.impl.light.LightIdentifier;
 
+import java.util.Objects;
+
 /**
  * Date: 12.10.13 Time: 23:27
  */
 public class LombokLightIdentifier extends LightIdentifier {
+  private static final Logger LOG = Logger.getInstance(LombokLightIdentifier.class);
+
   private String myText;
 
   public LombokLightIdentifier(PsiManager manager, String text) {
@@ -47,7 +52,14 @@ public class LombokLightIdentifier extends LightIdentifier {
 
     LombokLightIdentifier that = (LombokLightIdentifier) o;
 
-    return !(myText != null ? !myText.equals(that.myText) : that.myText != null);
+    if(getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
+      if(Objects.equals(myText, that.myText)) {
+        LOG.warn("Usually I would have been equal!");
+      }
+      return false;
+    }
+
+    return Objects.equals(myText, that.myText);
 
   }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightIdentifier.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightIdentifier.java
@@ -1,6 +1,5 @@
 package de.plushnikov.intellij.plugin.psi;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiManager;
@@ -12,8 +11,6 @@ import java.util.Objects;
  * Date: 12.10.13 Time: 23:27
  */
 public class LombokLightIdentifier extends LightIdentifier {
-  private static final Logger LOG = Logger.getInstance(LombokLightIdentifier.class);
-
   private String myText;
 
   public LombokLightIdentifier(PsiManager manager, String text) {
@@ -53,9 +50,6 @@ public class LombokLightIdentifier extends LightIdentifier {
     LombokLightIdentifier that = (LombokLightIdentifier) o;
 
     if(getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
-      if(Objects.equals(myText, that.myText)) {
-        LOG.warn("Usually I would have been equal!");
-      }
       return false;
     }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightMethodBuilder.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightMethodBuilder.java
@@ -2,6 +2,7 @@ package de.plushnikov.intellij.plugin.psi;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.java.JavaLanguage;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.CheckUtil;
@@ -23,6 +24,8 @@ import java.util.Objects;
  * @author Plushnikov Michail
  */
 public class LombokLightMethodBuilder extends LightMethodBuilder {
+  private static final Logger LOG = Logger.getInstance(LombokLightMethodBuilder.class);
+
   private PsiMethod myMethod;
   private ASTNode myASTNode;
   private PsiCodeBlock myBodyCodeBlock;
@@ -287,6 +290,14 @@ public class LombokLightMethodBuilder extends LightMethodBuilder {
     if (!getParameterList().equals(that.getParameterList())) {
       return false;
     }
+
+    if(getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
+      if(Objects.equals(myReturnTypeAsText, that.myReturnTypeAsText)) {
+        LOG.warn("Usually I would have been equal!");
+      }
+      return false;
+    }
+
     return Objects.equals(myReturnTypeAsText, that.myReturnTypeAsText);
   }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightMethodBuilder.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightMethodBuilder.java
@@ -2,7 +2,6 @@ package de.plushnikov.intellij.plugin.psi;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.java.JavaLanguage;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.CheckUtil;
@@ -24,8 +23,6 @@ import java.util.Objects;
  * @author Plushnikov Michail
  */
 public class LombokLightMethodBuilder extends LightMethodBuilder {
-  private static final Logger LOG = Logger.getInstance(LombokLightMethodBuilder.class);
-
   private PsiMethod myMethod;
   private ASTNode myASTNode;
   private PsiCodeBlock myBodyCodeBlock;
@@ -292,9 +289,6 @@ public class LombokLightMethodBuilder extends LightMethodBuilder {
     }
 
     if(getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
-      if(Objects.equals(myReturnTypeAsText, that.myReturnTypeAsText)) {
-        LOG.warn("Usually I would have been equal!");
-      }
       return false;
     }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightModifierList.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightModifierList.java
@@ -1,6 +1,7 @@
 package de.plushnikov.intellij.plugin.psi;
 
 import com.intellij.lang.Language;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiAnnotation;
@@ -23,6 +24,7 @@ import java.util.Set;
  * @author Plushnikov Michail
  */
 public class LombokLightModifierList extends LightModifierList {
+  private static final Logger LOG = Logger.getInstance(LombokLightModifierList.class);
   private static final Set<String> ALL_MODIFIERS = new HashSet<>(Arrays.asList(PsiModifier.MODIFIERS));
 
   private final Map<String, PsiAnnotation> myAnnotations;
@@ -123,6 +125,13 @@ public class LombokLightModifierList extends LightModifierList {
     }
 
     LombokLightModifierList that = (LombokLightModifierList) o;
+
+    if (getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
+      if(myAnnotations.equals(that.myAnnotations)) {
+        LOG.warn("Usually I would have been equal!");
+      }
+      return false;
+    }
 
     return myAnnotations.equals(that.myAnnotations);
   }

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightModifierList.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightModifierList.java
@@ -1,7 +1,6 @@
 package de.plushnikov.intellij.plugin.psi;
 
 import com.intellij.lang.Language;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiAnnotation;
@@ -24,7 +23,6 @@ import java.util.Set;
  * @author Plushnikov Michail
  */
 public class LombokLightModifierList extends LightModifierList {
-  private static final Logger LOG = Logger.getInstance(LombokLightModifierList.class);
   private static final Set<String> ALL_MODIFIERS = new HashSet<>(Arrays.asList(PsiModifier.MODIFIERS));
 
   private final Map<String, PsiAnnotation> myAnnotations;
@@ -127,9 +125,6 @@ public class LombokLightModifierList extends LightModifierList {
     LombokLightModifierList that = (LombokLightModifierList) o;
 
     if (getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
-      if(myAnnotations.equals(that.myAnnotations)) {
-        LOG.warn("Usually I would have been equal!");
-      }
       return false;
     }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightParameter.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightParameter.java
@@ -1,7 +1,6 @@
 package de.plushnikov.intellij.plugin.psi;
 
 import com.intellij.lang.Language;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiIdentifier;
@@ -19,8 +18,6 @@ import java.util.Collections;
  * @author Plushnikov Michail
  */
 public class LombokLightParameter extends LightParameter {
-  private static final Logger LOG = Logger.getInstance(LombokLightParameter.class);
-
   private String myName;
   private final LombokLightIdentifier myNameIdentifier;
 
@@ -81,9 +78,6 @@ public class LombokLightParameter extends LightParameter {
     }
 
     if(getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
-      if(thisType.getCanonicalText().equals(thatType.getCanonicalText())) {
-        LOG.warn("Usually I would have been equal!");
-      }
       return false;
     }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightParameter.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightParameter.java
@@ -1,6 +1,7 @@
 package de.plushnikov.intellij.plugin.psi;
 
 import com.intellij.lang.Language;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiIdentifier;
@@ -18,6 +19,8 @@ import java.util.Collections;
  * @author Plushnikov Michail
  */
 public class LombokLightParameter extends LightParameter {
+  private static final Logger LOG = Logger.getInstance(LombokLightParameter.class);
+
   private String myName;
   private final LombokLightIdentifier myNameIdentifier;
 
@@ -74,6 +77,13 @@ public class LombokLightParameter extends LightParameter {
     final PsiType thisType = getType();
     final PsiType thatType = that.getType();
     if (thisType.isValid() != thatType.isValid()) {
+      return false;
+    }
+
+    if(getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
+      if(thisType.getCanonicalText().equals(thatType.getCanonicalText())) {
+        LOG.warn("Usually I would have been equal!");
+      }
       return false;
     }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightParameterListBuilder.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightParameterListBuilder.java
@@ -1,12 +1,15 @@
 package de.plushnikov.intellij.plugin.psi;
 
 import com.intellij.lang.Language;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.impl.light.LightParameterListBuilder;
 
 import java.util.Arrays;
 
 public class LombokLightParameterListBuilder extends LightParameterListBuilder {
+  private static final Logger LOG = Logger.getInstance(LombokLightParameterListBuilder.class);
+
   public LombokLightParameterListBuilder(PsiManager manager, Language language) {
     super(manager, language);
   }
@@ -23,6 +26,13 @@ public class LombokLightParameterListBuilder extends LightParameterListBuilder {
     LombokLightParameterListBuilder that = (LombokLightParameterListBuilder) o;
 
     if (getParametersCount() != that.getParametersCount()) {
+      return false;
+    }
+
+    if(getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
+      if(Arrays.equals(getParameters(), that.getParameters())) {
+        LOG.warn("Usually I would have been equal!");
+      }
       return false;
     }
 

--- a/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightParameterListBuilder.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/psi/LombokLightParameterListBuilder.java
@@ -1,14 +1,12 @@
 package de.plushnikov.intellij.plugin.psi;
 
 import com.intellij.lang.Language;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.impl.light.LightParameterListBuilder;
 
 import java.util.Arrays;
 
 public class LombokLightParameterListBuilder extends LightParameterListBuilder {
-  private static final Logger LOG = Logger.getInstance(LombokLightParameterListBuilder.class);
 
   public LombokLightParameterListBuilder(PsiManager manager, Language language) {
     super(manager, language);
@@ -30,9 +28,6 @@ public class LombokLightParameterListBuilder extends LightParameterListBuilder {
     }
 
     if(getNavigationElement() != this && !getNavigationElement().equals(that.getNavigationElement())) {
-      if(Arrays.equals(getParameters(), that.getParameters())) {
-        LOG.warn("Usually I would have been equal!");
-      }
       return false;
     }
 


### PR DESCRIPTION
This seems to solve issues related to psi becoming outdated due to the returned navigation element being invalid.
Covers issues: fix #821, fix #827, fix #829, fix #840, fix #842, fix #844, fix #846, fix #850, fix #853, fix #854, fix #855, fix #857, fix #861, fix #862, fix #863, fix #864, fix #865, fix #867, fix #868, fix #869

I did some debugging of when the equals method returns false when it previously returned true. Seemed to be first triggered by the worker thread which handles icons on the platform. I'm afraid I didn't get much further into figuring out what's changed on the platform to cause this.

This PR is an extension of the comment by @ajchun:
https://github.com/mplushnikov/lombok-intellij-plugin/issues/840#issuecomment-666085509

I also did another Pull Request #856 which removed some warnings related to the use of constructor injection