### PR TITLE
Stop setting the untilBuild field in the plugin.xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ intellij {
 
 patchPluginXml {
   version artifactVersion
-
+  untilBuild null //Dumps the until-build field from getting populated.
   pluginDescription(file(descriptionFile).text)
   changeNotes(file(changesFile).text)
 }


### PR DESCRIPTION
Stop setting the untilBuild field in the plugin.xml