### PR TITLE
Fix for #838. Suppress wrong warnings.

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/extension/LombokHighlightErrorFilter.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/extension/LombokHighlightErrorFilter.java
@@ -1,5 +1,11 @@
 package de.plushnikov.intellij.plugin.extension;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 import com.intellij.codeInsight.daemon.JavaErrorBundle;
 import com.intellij.codeInsight.daemon.impl.HighlightInfo;
 import com.intellij.codeInsight.daemon.impl.HighlightInfoFilter;
@@ -7,15 +13,26 @@ import com.intellij.codeInsight.intention.AddAnnotationFix;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.editor.colors.CodeInsightColors;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
-import com.intellij.psi.*;
+import com.intellij.psi.PsiClassInitializer;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiLambdaExpression;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiMethodReferenceExpression;
+import com.intellij.psi.PsiModifierListOwner;
+import com.intellij.psi.PsiReferenceExpression;
 import com.intellij.psi.util.PsiTreeUtil;
-import de.plushnikov.intellij.plugin.handler.*;
+import de.plushnikov.intellij.plugin.handler.BuilderHandler;
+import de.plushnikov.intellij.plugin.handler.EqualsAndHashCodeCallSuperHandler;
+import de.plushnikov.intellij.plugin.handler.FieldNameConstantsHandler;
+import de.plushnikov.intellij.plugin.handler.LazyGetterHandler;
+import de.plushnikov.intellij.plugin.handler.OnXAnnotationHandler;
+import de.plushnikov.intellij.plugin.util.PsiAnnotationSearchUtil;
+import lombok.Builder;
 import lombok.SneakyThrows;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.*;
-import java.util.regex.Pattern;
 
 
 public class LombokHighlightErrorFilter implements HighlightInfoFilter {
@@ -196,6 +213,36 @@ public class LombokHighlightErrorFilter implements HighlightInfoFilter {
       public boolean accept(@NotNull PsiElement highlightedElement) {
         return !EqualsAndHashCodeCallSuperHandler.isEqualsAndHashCodeCallSuperDefault(highlightedElement);
       }
+    },
+
+    /**
+     * Handles warnings that are related to Builder.Default cause.
+     * The final fields that are marked with Builder.Default contains only possible value because user can set another value during the creation of the object.
+     */
+    CONSTANT_CONDITIONS_DEFAULT_BUILDER_CAN_BE_SIMPLIFIED(HighlightSeverity.WARNING, CodeInsightColors.WARNINGS_ATTRIBUTES) {
+      private final Pattern patternCanBeSimplified = Pattern.compile("'.+' can be simplified to '.+'");
+      private final Pattern patternIsAlways = Pattern.compile("Condition '.+' is always '(true|false)'");
+
+      @Override
+      public boolean descriptionCheck(@Nullable String description) {
+        return description != null
+          && (patternCanBeSimplified.matcher(description).matches() || patternIsAlways.matcher(description).matches());
+      }
+
+      @Override
+      public boolean accept(@NotNull PsiElement highlightedElement) {
+        PsiReferenceExpression parent = PsiTreeUtil.getParentOfType(highlightedElement, PsiReferenceExpression.class);
+        if (parent == null) {
+          return true;
+        }
+
+        PsiElement resolve = parent.resolve();
+        if (!(resolve instanceof PsiField)) {
+          return true;
+        }
+
+        return !PsiAnnotationSearchUtil.isAnnotatedWith((PsiField) resolve, Builder.Default.class.getCanonicalName());
+      }
     };
 
     private final HighlightSeverity severity;
@@ -206,8 +253,16 @@ public class LombokHighlightErrorFilter implements HighlightInfoFilter {
       this.key = key;
     }
 
+    /**
+     * @param description of the current highlighted element
+     * @return true if the filter can handle current type of the highlight info with that kind of the description
+     */
     abstract public boolean descriptionCheck(@Nullable String description);
 
+    /**
+     * @param highlightedElement the deepest element (it's the leaf element in PSI tree where the highlight was occurred)
+     * @return false if the highlight should be suppressed
+     */
     abstract public boolean accept(@NotNull PsiElement highlightedElement);
   }
 }

--- a/src/test/java/de/plushnikov/intellij/plugin/inspection/DataFlowInspectionWithDisabledCachingTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/inspection/DataFlowInspectionWithDisabledCachingTest.java
@@ -1,0 +1,31 @@
+package de.plushnikov.intellij.plugin.inspection;
+
+import com.intellij.codeInspection.InspectionProfileEntry;
+import com.intellij.codeInspection.dataFlow.DataFlowInspection;
+import com.intellij.openapi.util.RecursionManager;
+
+
+public class DataFlowInspectionWithDisabledCachingTest extends LombokInspectionTest {
+
+  @Override
+  protected String getTestDataPath() {
+    return TEST_DATA_INSPECTION_DIRECTORY + "/diverse";
+  }
+
+  @Override
+  protected InspectionProfileEntry getInspection() {
+    return new DataFlowInspection();
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    //TODO disable assertions for the moment
+    RecursionManager.disableMissedCacheAssertions(myFixture.getProjectDisposable());
+  }
+
+  public void testDefaultBuilderFinalValueInspectionIsAlwaysThat() {
+    doTest();
+  }
+}

--- a/src/test/java/de/plushnikov/intellij/plugin/inspection/PointlessBooleanExpressionInspectionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/inspection/PointlessBooleanExpressionInspectionTest.java
@@ -1,0 +1,33 @@
+package de.plushnikov.intellij.plugin.inspection;
+
+import com.intellij.codeInspection.InspectionProfileEntry;
+import com.intellij.openapi.util.RecursionManager;
+import com.siyeh.ig.controlflow.PointlessBooleanExpressionInspection;
+
+
+/**
+ * @author Lekanich
+ */
+public class PointlessBooleanExpressionInspectionTest extends LombokInspectionTest {
+  @Override
+  protected String getTestDataPath() {
+    return TEST_DATA_INSPECTION_DIRECTORY + "/pointlessBooleanExpression";
+  }
+
+  @Override
+  protected InspectionProfileEntry getInspection() {
+    return new PointlessBooleanExpressionInspection();
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    //TODO disable assertions for the moment
+    RecursionManager.disableMissedCacheAssertions(myFixture.getProjectDisposable());
+  }
+
+  public void testPointlessBooleanExpressionBuilderDefault() {
+    doTest();
+  }
+}

--- a/testData/inspection/diverse/DefaultBuilderFinalValueInspectionIsAlwaysThat.java
+++ b/testData/inspection/diverse/DefaultBuilderFinalValueInspectionIsAlwaysThat.java
@@ -1,0 +1,26 @@
+import lombok.Builder;
+
+@Builder
+public class DefaultBuilderFinalValueInspectionIsAlwaysThat {
+  @Builder.Default final boolean b = true;
+  @Builder.Default final int i = -1;
+  @Builder.Default final String s = "";
+  @Builder.Default final Object o = new Object();
+  final String thisIsTrueFinalField = "";
+
+  public void test() {
+    // Doesn't occur here
+    if (b) System.out.println("no warning");
+
+    // But does occur here and with other primitives
+    if (b ==  true) System.out.println("ConstantConditions");
+    if (i == 0) System.out.println("ConstantConditions");
+
+    // Does occur on objects
+    if (s.isEmpty()) System.out.println("ConstantConditions");
+    if (o == null) System.out.println("ConstantConditions");
+
+    // Must occur here
+    if (<warning descr="Condition 'thisIsTrueFinalField.isEmpty()' is always 'true'">thisIsTrueFinalField.isEmpty()</warning>) System.out.println("ConstantConditions");
+  }
+}

--- a/testData/inspection/pointlessBooleanExpression/PointlessBooleanExpressionBuilderDefault.java
+++ b/testData/inspection/pointlessBooleanExpression/PointlessBooleanExpressionBuilderDefault.java
@@ -1,0 +1,21 @@
+import lombok.Builder;
+
+
+@Builder
+public class PointlessBooleanExpressionBuilderDefault {
+  @Builder.Default
+  final boolean b = true;
+  final boolean bIsTrueFinal = true;
+
+  public void test() {
+    // should be here
+    if (<warning descr="'bIsTrueFinal == true' can be simplified to 'bIsTrueFinal'">bIsTrueFinal == true</warning>) {
+      System.out.println("ConstantConditions");
+    }
+
+    // shouldn't be here because the b is not 100% initialized with 'true' value
+    if (b == true) {
+      System.out.println("ConstantConditions");
+    }
+  }
+}


### PR DESCRIPTION
- for final Builder.Default fields
-- suppress warnings: "Condition is always true|false"
-- suppress warnings: "can be simplified to"