### PR TITLE
#799 Fix SneakyThrows in lambdas

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/handler/SneakyThrowsExceptionHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/handler/SneakyThrowsExceptionHandler.java
@@ -27,12 +27,11 @@ public class SneakyThrowsExceptionHandler extends CustomExceptionHandler {
       return false;
     } else if (parent instanceof PsiTryStatement && isHandledByTryCatch(exceptionType, (PsiTryStatement) parent)) {
       // that exception MAY be already handled by regular try-catch statement
-      // (just in case should be handled in another way but if somebody decided to reused method for their check)
       return false;
     }
 
     if (topElement instanceof PsiTryStatement && isHandledByTryCatch(exceptionType, (PsiTryStatement) topElement)) {
-      // that exception MAY be already handled by regular try-catch statement
+      // that exception MAY be already handled by regular try-catch statement (don't forget about nested try-catch)
       return false;
     } else if (!(topElement instanceof PsiCodeBlock)) {
       final PsiMethod psiMethod = PsiTreeUtil.getParentOfType(element, PsiMethod.class);

--- a/src/main/java/de/plushnikov/intellij/plugin/handler/SneakyThrowsExceptionHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/handler/SneakyThrowsExceptionHandler.java
@@ -21,21 +21,31 @@ public class SneakyThrowsExceptionHandler extends CustomExceptionHandler {
 
   @Override
   public boolean isHandled(@Nullable PsiElement element, @NotNull PsiClassType exceptionType, PsiElement topElement) {
-    // that exception may be already handled by regular try-catch statement
-    if (topElement instanceof PsiTryStatement) {
-      List<PsiType> caughtExceptions = Stream.of(((PsiTryStatement) topElement).getCatchBlockParameters())
-        .map(PsiParameter::getType)
-        .collect(Collectors.toList());
-      if (isExceptionHandled(exceptionType, caughtExceptions)) {
-        return false;
-      }
+    PsiElement parent = PsiTreeUtil.getParentOfType(element, PsiLambdaExpression.class, PsiTryStatement.class, PsiMethod.class);
+    if (parent instanceof PsiLambdaExpression) {
+      // lambda it's another scope, @SneakyThrows annotation can't neglect exceptions in lambda only on method, constructor
+      return false;
+    } else if (parent instanceof PsiTryStatement && isHandledByTryCatch(exceptionType, (PsiTryStatement) parent)) {
+      // that exception MAY be already handled by regular try-catch statement
+      // (just in case should be handled in another way but if somebody decided to reused method for their check)
+      return false;
     }
 
-    if (!(topElement instanceof PsiCodeBlock)) {
+    if (topElement instanceof PsiTryStatement && isHandledByTryCatch(exceptionType, (PsiTryStatement) topElement)) {
+      // that exception MAY be already handled by regular try-catch statement
+      return false;
+    } else if (!(topElement instanceof PsiCodeBlock)) {
       final PsiMethod psiMethod = PsiTreeUtil.getParentOfType(element, PsiMethod.class);
       return psiMethod != null && isExceptionHandled(psiMethod, exceptionType);
     }
     return false;
+  }
+
+  private boolean isHandledByTryCatch(@NotNull PsiClassType exceptionType, PsiTryStatement topElement) {
+    List<PsiType> caughtExceptions = Stream.of(topElement.getCatchBlockParameters())
+      .map(PsiParameter::getType)
+      .collect(Collectors.toList());
+    return isExceptionHandled(exceptionType, caughtExceptions);
   }
 
   private boolean isExceptionHandled(@NotNull PsiModifierListOwner psiModifierListOwner, PsiClassType exceptionClassType) {

--- a/src/test/java/de/plushnikov/intellij/plugin/SneakyThrowsTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/SneakyThrowsTest.java
@@ -95,6 +95,41 @@ public class SneakyThrowsTest extends LightJavaCodeInsightTestCase {
     assertSize(0, exceptions);
   }
 
+  public void testTryCatchThatCatchAnotherExceptionWithNullTopElement() {
+    PsiMethodCallExpression methodCall = createCall("@lombok.SneakyThrows\n" +
+      "    public void m() {\n" +
+      "        try {\n" +
+      "            throwsMyException();" +
+      "            throwsSomeException();" +
+      "        } catch (Test.SomeException e) {\n" +
+      "        }\n" +
+      "    }");
+    List<PsiClassType> exceptions = ExceptionUtil.getUnhandledExceptions(methodCall, null);
+    assertSize(0, exceptions);
+  }
+
+  public void testTryCatchThatCatchAnotherExceptionHierarchy() {
+    PsiFile file = createTestFile("@lombok.SneakyThrows\n" +
+      "    public void m() {\n" +
+      "        try {\n" +
+      "            try {" +
+      "                throwsMyException();\n" +
+      "                throwsSomeException();" +
+      "                throwsAnotherException();" +
+      "            } catch (Test.SomeException e) {}\n" +
+      "        } catch (Test.AnotherException e) {}\n" +
+      "    }");
+
+    PsiMethodCallExpression methodCall = findMethodCall(file);
+    assertNotNull(methodCall);
+
+    PsiTryStatement tryStatement = findFirstChild(file, PsiTryStatement.class);
+    assertNotNull(tryStatement);
+
+    List<PsiClassType> exceptions = ExceptionUtil.getUnhandledExceptions(methodCall, null);
+    assertSize(0, exceptions);
+  }
+
   /**
    * to avoid catching all exceptions by default by accident
    */
@@ -120,11 +155,13 @@ public class SneakyThrowsTest extends LightJavaCodeInsightTestCase {
   @NotNull
   private PsiFile createTestFile(@NonNls String body) {
     return createFile("test.java", "class Test { " + body +
+      "void throwsAnotherException() throws AnotherException {}" +
       "void throwsMyException() throws MyException {}" +
       "void throwsSomeException() throws SomeException {}" +
       "static class MyException extends Exception {}" +
       "static class SomeException extends Exception {}" +
-      "static class Exception {}" +
+      "static class AnotherException extends Exception {}" +
+      "static class Exception{}" +
       "}");
   }
 

--- a/src/test/java/de/plushnikov/intellij/plugin/highlights/AbstractLombokHighlightsTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/highlights/AbstractLombokHighlightsTest.java
@@ -1,0 +1,37 @@
+package de.plushnikov.intellij.plugin.highlights;
+
+import com.intellij.codeInspection.InspectionProfileEntry;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.testFramework.LightProjectDescriptor;
+import com.siyeh.ig.LightJavaInspectionTestCase;
+import de.plushnikov.intellij.plugin.LombokTestUtil;
+import org.jetbrains.annotations.NotNull;
+
+
+/**
+ * @author Lekanich
+ */
+public abstract class AbstractLombokHighlightsTest extends LightJavaInspectionTestCase {
+  public static final String TEST_DATA_INSPECTION_DIRECTORY = "testData/highlights";
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    LombokTestUtil.loadLombokLibrary(myFixture.getProjectDisposable(), getModule());
+
+    Registry.get("platform.random.idempotence.check.rate").setValue(1, getTestRootDisposable());
+  }
+
+  @NotNull
+  @Override
+  protected LightProjectDescriptor getProjectDescriptor() {
+    return LombokTestUtil.getProjectDescriptor();
+  }
+
+  @Override
+  protected InspectionProfileEntry getInspection() {
+    return null;
+  }
+}
+

--- a/src/test/java/de/plushnikov/intellij/plugin/highlights/SneakyThrowsHighlightTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/highlights/SneakyThrowsHighlightTest.java
@@ -1,0 +1,16 @@
+package de.plushnikov.intellij.plugin.highlights;
+
+/**
+ * @author Lekanich
+ */
+public class SneakyThrowsHighlightTest extends AbstractLombokHighlightsTest {
+
+  @Override
+  protected String getTestDataPath() {
+    return TEST_DATA_INSPECTION_DIRECTORY + "/sneakyThrows";
+  }
+
+  public void testSneakThrowsCheckThatSneakyThrowsDoesntCatchCaughtException() {
+    doTest();
+  }
+}

--- a/src/test/java/de/plushnikov/intellij/plugin/highlights/SneakyThrowsHighlightTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/highlights/SneakyThrowsHighlightTest.java
@@ -10,7 +10,11 @@ public class SneakyThrowsHighlightTest extends AbstractLombokHighlightsTest {
     return TEST_DATA_INSPECTION_DIRECTORY + "/sneakyThrows";
   }
 
-  public void testSneakThrowsCheckThatSneakyThrowsDoesntCatchCaughtException() {
+  public void testSneakThrowsDoesntCatchCaughtException() {
+    doTest();
+  }
+
+  public void testSneakThrowsDoesntCatchCaughtExceptionNested() {
     doTest();
   }
 }

--- a/src/test/java/de/plushnikov/intellij/plugin/inspection/DataFlowWithDisabledCachingInspectionTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/inspection/DataFlowWithDisabledCachingInspectionTest.java
@@ -5,7 +5,7 @@ import com.intellij.codeInspection.dataFlow.DataFlowInspection;
 import com.intellij.openapi.util.RecursionManager;
 
 
-public class DataFlowInspectionWithDisabledCachingTest extends LombokInspectionTest {
+public class DataFlowWithDisabledCachingInspectionTest extends LombokInspectionTest {
 
   @Override
   protected String getTestDataPath() {

--- a/testData/highlights/sneakyThrows/SneakThrowsCheckThatSneakyThrowsDoesntCatchCaughtException.java
+++ b/testData/highlights/sneakyThrows/SneakThrowsCheckThatSneakyThrowsDoesntCatchCaughtException.java
@@ -1,0 +1,16 @@
+import lombok.SneakyThrows;
+
+
+public class SneakThrowsCheckThatSneakyThrowsDoesntCatchCaughtException {
+
+  @SneakyThrows
+  public static void m() {
+    final String file;
+    try {
+      file = "classpath:data/resource.json";
+      new java.io.FileInputStream(file);
+    } catch (java.io.IOException e) {
+      System.out.println(<error descr="Variable 'file' might not have been initialized">file</error>);
+    }
+  }
+}

--- a/testData/highlights/sneakyThrows/SneakThrowsDoesntCatchCaughtException.java
+++ b/testData/highlights/sneakyThrows/SneakThrowsDoesntCatchCaughtException.java
@@ -1,7 +1,7 @@
 import lombok.SneakyThrows;
 
 
-public class SneakThrowsCheckThatSneakyThrowsDoesntCatchCaughtException {
+public class SneakThrowsDoesntCatchCaughtException {
 
   @SneakyThrows
   public static void m() {

--- a/testData/highlights/sneakyThrows/SneakThrowsDoesntCatchCaughtExceptionNested.java
+++ b/testData/highlights/sneakyThrows/SneakThrowsDoesntCatchCaughtExceptionNested.java
@@ -1,0 +1,42 @@
+import lombok.SneakyThrows;
+
+
+public class SneakThrowsDoesntCatchCaughtExceptionNested {
+
+  @lombok.SneakyThrows
+  public void m() {
+    String name;
+    try {
+      try {
+        name = "";
+        throwsMyException();
+        throwsSomeException();
+        throwsAnotherException();
+      } catch (SneakThrowsDoesntCatchCaughtExceptionNested.SomeException e) {
+      }
+    } catch (SneakThrowsDoesntCatchCaughtExceptionNested.AnotherException e) {
+      System.out.println(<error descr="Variable 'name' might not have been initialized">name</error>);
+    }
+  }
+
+  void throwsAnotherException() throws AnotherException {
+  }
+
+  void throwsMyException() throws MyException {
+  }
+
+  void throwsSomeException() throws SomeException {
+  }
+
+  static class MyException extends Exception {
+  }
+
+  static class SomeException extends Exception {
+  }
+
+  static class AnotherException extends Exception {
+  }
+
+  static class Exception extends Throwable {
+  }
+}


### PR DESCRIPTION
- fix SneakyThrows handling for lambdas and cover with tests
- add test to check the situation when exception was handled by try-catch instead of SneakyThrows
- rename test class