### PR TITLE
fix: disregard tolerated elements in wither unique check

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/processor/field/WitherFieldProcessor.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/processor/field/WitherFieldProcessor.java
@@ -98,6 +98,7 @@ public class WitherFieldProcessor extends AbstractFieldProcessor {
     final String psiFieldName = psiField.getName();
     if (fieldContainingClass != null) {
       final Collection<PsiMethod> classMethods = PsiClassUtil.collectClassMethodsIntern(fieldContainingClass);
+      filterToleratedElements(classMethods);
 
       final AccessorsInfo accessorsInfo = buildAccessorsInfo(psiField);
       final Collection<String> possibleWitherNames = LombokUtils.toAllWitherNames(accessorsInfo, psiFieldName, PsiType.BOOLEAN.equals(psiField.getType()));


### PR DESCRIPTION
Resolves IDE warnings/errors where `@With` method was not generated due to other methods with the same name, even when marked as `@Tolerated`.

Example:
```java
@RequiredArgsConstructor
public class WitherTolerateTest {
    @With
    private final Integer score;

    @Tolerate
    public WitherTolerateTest withScore(String score) {
        return withScore(Integer.parseInt(score));
    }
}
```
