### PR TITLE
Small performance improvement for nested loop

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/action/lombok/LombokLoggerHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/action/lombok/LombokLoggerHandler.java
@@ -33,10 +33,12 @@ public class LombokLoggerHandler extends BaseLombokHandler {
     final boolean lombokLoggerIsStatic = AbstractLogProcessor.isLoggerStatic(psiClass);
 
     for (AbstractLogProcessor logProcessor : logProcessors) {
+      String loggerType = logProcessor.getLoggerType(psiClass); // null when the custom log's declaration is invalid
+      if (loggerType == null) {
+        continue;
+      }
       for (PsiField psiField : psiClass.getFields()) {
-        String loggerType = logProcessor.getLoggerType(psiClass); // null when the custom log's declaration is invalid
-        if (loggerType != null && psiField.getType().equalsToText(loggerType)
-          && checkLoggerField(psiField, lombokLoggerName, lombokLoggerIsStatic)) {
+        if (psiField.getType().equalsToText(loggerType) && checkLoggerField(psiField, lombokLoggerName, lombokLoggerIsStatic)) {
           processLoggerField(psiField, psiClass, logProcessor, lombokLoggerName);
         }
       }


### PR DESCRIPTION
The loggerType doesn't need to be reassigned on each nested loop and you can skip iterating the fields in general when loggerType is null.