### PR TITLE
[lombok]: #1170 sneaky throws

### DIFF
--- a/src/main/java/de/plushnikov/intellij/plugin/handler/SneakyThrowsExceptionHandler.java
+++ b/src/main/java/de/plushnikov/intellij/plugin/handler/SneakyThrowsExceptionHandler.java
@@ -22,20 +22,10 @@ public class SneakyThrowsExceptionHandler extends CustomExceptionHandler {
 
   @Override
   public boolean isHandled(@Nullable PsiElement element, @NotNull PsiClassType exceptionType, PsiElement topElement) {
-    PsiElement parent = PsiTreeUtil.getParentOfType(element, PsiLambdaExpression.class, PsiTryStatement.class, PsiMethod.class);
-    if (parent instanceof PsiLambdaExpression) {
-      // lambda it's another scope, @SneakyThrows annotation can't neglect exceptions in lambda only on method, constructor
-      return false;
-    }
-    if (parent instanceof PsiTryStatement && isHandledByTryCatch(exceptionType, (PsiTryStatement)parent)) {
-      // that exception MAY be already handled by regular try-catch statement
+    if (isHandledByParent(element, exceptionType)) {
       return false;
     }
 
-    if (topElement instanceof PsiTryStatement && isHandledByTryCatch(exceptionType, (PsiTryStatement)topElement)) {
-      // that exception MAY be already handled by regular try-catch statement (don't forget about nested try-catch)
-      return false;
-    }
     if (!(topElement instanceof PsiCodeBlock)) {
       final PsiMethod psiMethod = PsiTreeUtil.getParentOfType(element, PsiMethod.class);
       if (psiMethod != null) {
@@ -47,6 +37,22 @@ public class SneakyThrowsExceptionHandler extends CustomExceptionHandler {
       }
     }
     return false;
+  }
+
+  private static boolean isHandledByParent(@Nullable PsiElement element, @NotNull PsiClassType exceptionType) {
+    PsiElement parent = PsiTreeUtil.getParentOfType(element, PsiLambdaExpression.class, PsiTryStatement.class, PsiMethod.class);
+    if (parent instanceof PsiMethod) {
+      // we out of the scope of the method, so the exception wasn't handled inside the method
+      return false;
+    } else if (parent instanceof PsiLambdaExpression) {
+      // lambda it's another scope, @SneakyThrows annotation can't neglect exceptions in lambda only on method, constructor
+      return true;
+    } else if (parent instanceof PsiTryStatement && isHandledByTryCatch(exceptionType, (PsiTryStatement) parent)) {
+      // that exception MAY be already handled by regular try-catch statement
+      return true;
+    }
+    // in case if the try block inside the lambda or inside another try-catch. GitHub issue: 1170
+	  return isHandledByParent(parent, exceptionType);
   }
 
   private static boolean isConstructorMethodWithExceptionInSiblingConstructorCall(@NotNull PsiMethod containingMethod,

--- a/src/test/java/de/plushnikov/intellij/plugin/highlights/SneakyThrowsHighlightTest.java
+++ b/src/test/java/de/plushnikov/intellij/plugin/highlights/SneakyThrowsHighlightTest.java
@@ -30,4 +30,8 @@ public class SneakyThrowsHighlightTest extends AbstractLombokHighlightsTest {
   public void testSneakThrowsDoesntCatchExceptionFromThisConstructor() {
     doTest();
   }
+
+  public void testSneakyThrowsTryInsideLambda() {
+    doTest();
+  }
 }

--- a/testData/highlights/sneakyThrows/SneakyThrowsTryInsideLambda.java
+++ b/testData/highlights/sneakyThrows/SneakyThrowsTryInsideLambda.java
@@ -1,0 +1,18 @@
+import lombok.SneakyThrows;
+
+public class SneakyThrowsTryInsideLambda {
+  @SneakyThrows
+  public static void m() {
+    Runnable r = () -> {
+      try (Reader reader = new <error descr = "Unhandled exception: java.io.FileNotFoundException" > FileReader </error>("")){
+      }
+    }
+  }
+
+  // everything is ok here
+  @SneakyThrows
+  void m2() {
+    try (Reader reader = new FileReader("")) {}
+  }
+
+}


### PR DESCRIPTION
* fix sneaky throws that can't handle the try inside lambda

Note: Checked it manually, but can't run the tests, because looks like since Lombok is inside Jetbrains you can use the newest SDK that isn't available for me. 

I should fix the issue #1170 